### PR TITLE
Add find-unbound

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def VERSION "0.3.0-SNAPSHOT")
 
 (defproject refactor-nrepl VERSION
-  :description "nREPL middleware to support editor agnostic refactoring"
+  :description "nREPL middleware to support editor-agnostic refactoring"
   :url "http://github.com/clojure-emacs/refactor-nrepl"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/refactor_nrepl/find_unbound.clj
+++ b/src/refactor_nrepl/find_unbound.clj
@@ -1,0 +1,35 @@
+(ns refactor-nrepl.find-unbound
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.tools.nrepl
+             [middleware :refer [set-descriptor!]]
+             [misc :refer [response-for]]
+             [transport :as transport]]
+            [refactor-nrepl.analyzer :refer [find-unbound-vars]]))
+
+(defn- find-unbound-reply [{:keys [transport form] :as msg}]
+  (try
+    (let [unbound (find-unbound-vars (edn/read-string form))]
+      (transport/send transport
+                      (response-for msg
+                                    :unbound (str/join " " unbound)
+                                    :status :done)))
+    (catch Exception e
+      (transport/send transport (response-for msg :error (.getMessage e))))))
+
+(defn wrap-find-unbound
+  [handler]
+  (fn [{:keys [op form] :as msg}]
+    (if (= "find-unbound" op)
+      (find-unbound-reply msg)
+      (handler msg))))
+
+(set-descriptor!
+ #'wrap-find-unbound
+ {:handles
+  {"find-unbound"
+   {:doc "Finds unbound vars in the input form. "
+    :requires {"form" "The form on which to work"}
+    :returns {"status" "done"
+              "error" "an error message, intended to be displayed to the user."
+              "unbound" "space separated list of unbound vars"}}}})

--- a/src/refactor_nrepl/ns/clean_ns.clj
+++ b/src/refactor_nrepl/ns/clean_ns.clj
@@ -10,8 +10,7 @@
   * Remove any duplication in the :require and :import form.
   * Remove any unused required namespaces or imported classes.
   * Returns nil when nothing is changed, so the client knows not to do anything."
-  (:require [clojure.string :as str]
-            [clojure.tools.namespace.parse :refer [read-ns-decl]]
+  (:require [clojure.tools.namespace.parse :refer [read-ns-decl]]
             [clojure.tools.nrepl
              [middleware :refer [set-descriptor!]]
              [misc :refer [response-for]]

--- a/src/refactor_nrepl/plugin.clj
+++ b/src/refactor_nrepl/plugin.clj
@@ -21,4 +21,5 @@
                  '[refactor-nrepl.refactor/wrap-refactor
                    refactor-nrepl.ns.clean-ns/wrap-clean-ns
                    refactor-nrepl.ns.resolve-missing/wrap-resolve-missing
+                   refactor-nrepl.find-unbound/wrap-find-unbound
                    refactor-nrepl.artifacts/wrap-artifacts])))


### PR DESCRIPTION
This op takes a form and returns all the vars that are unbound.  This is
intended to be used with extract-function in `clj-refactor`.
