### PR TITLE
Fix resolve-missing for records and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The goal of the op is to provide intelligent suggestions when the user wants to 
 
 The op requires `symbol` which represents a name to look up on the classpath.
 
-The return value `candidates` is a space separated string of candidates to import or require into the current ns.
+The return value `candidates` is an alist of `((candidate1 . type1) (candidate2 . type2) ...)` where type is in `#{:type :class :ns}` so we can branch on the 3 various way to import.  `:type` means the symbol resolved to a var created by `defrecord` or `deftype`, `:class` also includes interfaces.
 
 ### hotload-dependency
 

--- a/src/refactor_nrepl/client.clj
+++ b/src/refactor_nrepl/client.clj
@@ -219,14 +219,12 @@
   - symbol which is either a var or a class to resolve on the classpath
   - [transport] an optional transport used to communicate with the client"
   [& {transport :transport sym :symbol}]
-  (let [tr (or transport @transp (reset! transp (connect)))
-        candidates (-> (nrepl-message tr {:op :resolve-missing
-                                          :symbol sym})
-                       first
-                       :candidates)]
-    (when-not (str/blank? candidates)
-      (->> (str/split candidates #" ")
-           (map symbol)))))
+  (-> transport
+      (or @transp (reset! transp (connect)))
+      (nrepl-message {:op :resolve-missing :symbol sym})
+      first
+      :candidates
+      edn/read-string))
 
 (defn find-unbound
   "Finds unbound vars in the input form

--- a/test/refactor_nrepl/integration_tests.clj
+++ b/test/refactor_nrepl/integration_tests.clj
@@ -150,12 +150,33 @@
 
     (is (= new-three (slurp three-file)) "remove println failed")))
 
+(defrecord Foo [])
+(deftype Bar [])
+(definterface Baz)
+
 (deftest test-resolve-missing
   (let [transport (connect :port 7777)
-        split-candidates (resolve-missing :transport transport :symbol "split")
-        date-candidates (resolve-missing :transport transport :symbol "Date")]
-    (is ((set split-candidates) 'clojure.string))
-    (is ((set date-candidates) 'java.util.Date))))
+        split-res (resolve-missing :transport transport :symbol "split")
+        date-res (resolve-missing :transport transport :symbol "Date")
+        foo-res (resolve-missing :transport transport :symbol "Foo")
+        bar-res (resolve-missing :transport transport :symbol "Bar")
+        baz-res (resolve-missing :transport transport :symbol "Baz")
+        split-type (second (first (filter #(= (first %) 'clojure.string) split-res)))
+        date-type (second (first (filter #(= (first %) 'java.util.Date) date-res)))
+        foo-type (second (first (filter #(= (first %) 'refactor_nrepl.integration_tests.Foo)
+                                        foo-res)))
+        bar-type (second (first (filter #(= (first %) 'refactor_nrepl.integration_tests.Bar) bar-res)))
+        baz-type (second (first (filter #(= (first %) 'refactor_nrepl.integration_tests.Baz) baz-res)))]
+    (is ((set (map first split-res)) 'clojure.string))
+    (is ((set (map first date-res)) 'java.util.Date))
+    (is ((set (map first foo-res)) 'refactor_nrepl.integration_tests.Foo))
+    (is ((set (map first bar-res)) 'refactor_nrepl.integration_tests.Bar))
+    (is ((set (map first baz-res)) 'refactor_nrepl.integration_tests.Baz))
+    (is (= date-type :class))
+    (is (= foo-type :type))
+    (is (= bar-type :type))
+    (is (= baz-type :class))
+    (is (= split-type :ns))))
 
 (deftest find-local-arg
   (let [tmp-dir (create-test-project)


### PR DESCRIPTION
This also removes an assumption that capitalized names belong to
classes.  This prevented the resolution of e.g. schemas from
prismatic/schema, which are vars that conventionally start with capital
letters.

The return value of the op has changed.  We're now dropping :type because
it no longer contains the resolution we need on the client side.  We have
to be able determine the difference between a missing:

1) record or type, as created by defrecord or deftype, respectively
2) class
3) ns

The new return value is thus an alist of ((candidate1 . type1) (candidate
2 . type2) ...), where type is in #{:type :ns :class}.

A :type is generated by both defrecord or deftype becaues the client will
do the same in both cases.

Interfaces are included under :class because info-clj doesn't make the
distinction and the client doesn't have to branch on the information.

It's quite convenient to simply read in result alist on the elisp
side, but I imagine this might not be the case in clients written in other
languages.  If we ever get other consumers it should be easy enough to
change the representation, but I don't want to write that code now so I'm
hoping for YAGNI :)