### PR TITLE
Upgrade Apache httpclient dependency to 4.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  ^:source-dep [http-kit "2.1.19"]
                  [org.clojure/data.json "0.2.5"]
                  ^:source-dep [instaparse "1.3.4"]
-                 ^:source-dep [org.apache.httpcomponents/httpclient "4.3.5"]
+                 ^:source-dep [org.apache.httpcomponents/httpclient "4.4"]
                  ^:source-dep [com.cemerick/pomegranate "0.3.0"]
                  ^:source-dep [org.clojure/tools.analyzer.jvm "0.6.5"]
                  ^:source-dep [org.clojure/tools.namespace "0.2.7"]


### PR DESCRIPTION
Similar to #18...

I just spent quite a bit of time figuring out why [`org.apache.commons.codec.DigestUtils#getString(String)`](https://commons.apache.org/proper/commons-codec/apidocs/org/apache/commons/codec/digest/DigestUtils.html#getDigest(java.lang.String)) wasn't a public method during my SSL library unit tests (which has a dependency on `commons-codec "1.9"`).

Turns out a newer version of `httpclient` resolves this issue for me. 
* I bumped the version #, `lein install`ed it, started my Emacs Cider REPL, and did some refactorings - things seemed to still work.
* `lein test :all` passes locally

Also, let me give my :+1: to resolving these dependency issues as mentioned in #18 
