### PR TITLE
[Fix #29] Split refactor into several ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,31 @@ Takes one required argument, `artifact` which is the full name of the artifact e
 
 The return value is a space-separated list of all the available versions for the artifact.
 
-### find symbols
+### find-symbol
 
-Finds occurrences of symbols like defs and defns both where they are defined (if available) and where they are used.
+This op finds occurrences of a single symbol.
+
+`find-symbol` requires:
+
+`file` "The absolute path to the file containing the symbol to lookup.
+
+`dir` Only files below this dir will be searched.
+
+`ns` The ns where the symbol is defined.
+
+`name` The name of the symbol
+
+`line` The line number where the symbol occurrs.
+
+`column` The column number where the symbol occurs.
+
+The return value is a stream of occurrences under the key `occurrence` which is an alist like this:
+
+`(:line-beg 5 :line-end 5 :col-beg 19 :col-end 26 :name a-name :file \"/aboslute/path/to/file.clj\" :match (fn-name some args))`
+
+When the fine `occurrence` has been send a final message is sent with `count`, indicating the total number of matches, and `status` `done`.
+
+In the event of an error the key `error` will contain a message which is intended for display to the user.
 
 #### find usages (application of find symbols)
 

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Two ops are available:
 
 #### artifact-list
 
-Takes no arguments and returns a space-separated list of all available artifacts.
+Takes no arguments and returns a list of all available artifacts.
 
 #### artifact-versions
 
 Takes one required argument, `artifact` which is the full name of the artifact e.g. `core.clojure/clojure`, and one optional argument `force` which indicates whether we should force an update of the cached artifacts.
 
-The return value is a space-separated list of all the available versions for the artifact.
+The return value is a list of all the available versions for the artifact.
 
 ### find-symbol
 

--- a/src/refactor_nrepl/artifacts.clj
+++ b/src/refactor_nrepl/artifacts.clj
@@ -88,17 +88,14 @@
 (defn- artifacts-list [{:keys [transport force] :as msg}]
   (when (or (= force "true") (stale-cache?))
     (update-artifact-cache!))
-  (let [names (->> @artifacts
-                   keys
-                   (interpose " ")
-                   (apply str))]
-    (transport/send transport (response-for msg :value names :status :done))))
+  (let [names (->> @artifacts keys list*)]
+    (transport/send transport (response-for msg :artifacts names :status :done))))
 
 (defn- artifact-versions [{:keys [transport artifact] :as msg}]
   (when (stale-cache?)
     (update-artifact-cache!))
-  (let [versions (->> artifact (@artifacts) (interpose " ") (apply str))]
-    (transport/send transport (response-for msg :value versions  :status :done))))
+  (let [versions (->> artifact (@artifacts) list)]
+    (transport/send transport (response-for msg :versions versions  :status :done))))
 
 (defn- hotload-dependency
   [{:keys [transport coordinates] :as msg}]
@@ -135,13 +132,13 @@
     :requires {}
     :optional {"force" "which, if present, indicates whether we should force an update of the list of artifacts, rather than use the cache."}
     :returns {"status" "done"
-              "value" "string containing artifacts, separated by spaces."}}
+              "artifacts" "List of strings of artifacts."}}
    "artifact-versions"
    {:doc "Get all the available versions for an artifact."
     :requires {"artifact" "the artifact whose versions we're interested in"}
     :optional {}
     :returns {"status" "done"
-              "value" "string containing artifact versions, separated by spaces."}}
+              "versions" "List of strings of artifact versions."}}
    "hotload-dependency"
    {:doc "Adds non-conflicting dependency changes to active nrepl."
     :requires {:coordinates "A leiningen coordinate vector"}

--- a/src/refactor_nrepl/plugin.clj
+++ b/src/refactor_nrepl/plugin.clj
@@ -18,7 +18,7 @@
                  [['refactor-nrepl (version)]])
       (update-in [:repl-options :nrepl-middleware]
                  (fnil into [])
-                 '[refactor-nrepl.refactor/wrap-refactor
+                 '[refactor-nrepl.find-symbol/wrap-find-symbol
                    refactor-nrepl.ns.clean-ns/wrap-clean-ns
                    refactor-nrepl.ns.resolve-missing/wrap-resolve-missing
                    refactor-nrepl.find-unbound/wrap-find-unbound


### PR DESCRIPTION
- Rename refactor.clj => find_symbol.clj
- Create a new toplevel op find-symbol
- Create a new toplevel op find-debug-fns
- Change the name of some of the parameters to find-symbol:
  loc-line => line, loc-column => column, clj-dir => dir
- The return value of find-symbol is changed from [4 4 3 20 println ...]
  to a plist with the following keys: :line-beg :line-end :col-beg
  :col-end :name :path :match.
- Expanded the readme to better document find-symbol