### PR TITLE
extract-fn rework: fixes #45

### DIFF
--- a/resources/testproject/src/com/example/five.clj
+++ b/resources/testproject/src/com/example/five.clj
@@ -4,6 +4,14 @@
 ;;  remove parameters to run the tests
 (defn fn-with-unbounds [s sep]
   (when-not (blank? s)
-    (-> s (split " ")
+    (-> s (split #" ")
         (join sep)
         trim)))
+
+(defn orig-fn [s]
+  (let [sep ";"]
+    (when-not (blank? s)
+      (-> s
+          (split #" ")
+          ((partial join sep))
+          trim))))

--- a/src/refactor_nrepl/analyzer.clj
+++ b/src/refactor_nrepl/analyzer.clj
@@ -1,13 +1,10 @@
 (ns refactor-nrepl.analyzer
   (:refer-clojure :exclude [macroexpand-1])
-  (:require [clojure.tools.analyzer :as ana]
+  (:require [clojure.java.io :as io]
+            [clojure.tools.analyzer :as ana]
             [clojure.tools.analyzer.jvm :as aj]
             [clojure.tools.analyzer.jvm.utils :as ajutils]
-            [clojure.tools.analyzer.passes :refer [schedule]]
-            [clojure.tools.analyzer.passes.jvm.validate :refer [validate]]
-            [clojure.tools.namespace.parse :refer [read-ns-decl]]
-            [clojure.tools.analyzer.passes.emit-form :as emit-form]
-            [clojure.java.io :as io])
+            [clojure.tools.namespace.parse :refer [read-ns-decl]])
   (:import java.io.PushbackReader))
 
 ;;; The structure here is {ns {content-hash ast}}
@@ -73,20 +70,3 @@
     (catch Exception ex
       (throw (IllegalStateException.
               (str (first (parse-ns file-content)) " is in a bad state!"))))))
-
-;;; Used in eval+analyze to emit code for later evaluation
-;;; This isn't really of interest to us, so this is a no-op
-(defmethod clojure.tools.analyzer.passes.emit-form/-emit-form ::unresolved-sym
-  [& _])
-
-(defn find-unbound-vars [namespace]
-  (let [unbound (atom #{})]
-    (binding [aj/run-passes (schedule #{#'validate})
-              ana/macroexpand-1 noop-macroexpand-1]
-      (aj/analyze-ns namespace (aj/empty-env)
-                     {:passes-opts
-                      {:validate/unresolvable-symbol-handler
-                       (fn [_ var-name orig-ast]  (swap! unbound conj var-name)
-                         {:op ::unresolved-sym :sym var-name :env (:env orig-ast)
-                          :form (:form orig-ast)})}}))
-    @unbound))

--- a/src/refactor_nrepl/client.clj
+++ b/src/refactor_nrepl/client.clj
@@ -200,11 +200,16 @@
   Expected input:
   - ns which is the ns to be analyzed for unbound vars
   - [transport] an optional transport used to communicate with the client"
-  [& {:keys [transport ns]}]
+  [& {:keys [transport file line column]}]
   (let [tr (or transport @transp (reset! transp (connect)))
         response (nrepl-message tr {:op :find-unbound
-                                    :ns ns})
-        unbound (:unbound (first response))]
+                                    :file file
+                                    :line line
+                                    :column column})
+        unbound (:unbound (first response))
+        error (:error (first response))]
+    (when error
+      (println "something bad happened: " error))
     (if-not (str/blank? unbound)
       (->> (str/split unbound #" ")
            (map symbol)

--- a/src/refactor_nrepl/find_unbound.clj
+++ b/src/refactor_nrepl/find_unbound.clj
@@ -1,14 +1,37 @@
 (ns refactor-nrepl.find-unbound
-  (:require [clojure.string :as str]
+  (:require [clojure
+             [set :as set]
+             [string :as str]]
+            [clojure.tools.analyzer.ast :refer :all]
             [clojure.tools.nrepl
              [middleware :refer [set-descriptor!]]
              [misc :refer [response-for]]
              [transport :as transport]]
-            [refactor-nrepl.analyzer :refer [find-unbound-vars]]))
+            [refactor-nrepl
+             [analyzer :refer [ns-ast]]
+             [util :refer :all]]))
 
-(defn- find-unbound-reply [{:keys [transport ns] :as msg}]
+(defn- find-unbound-vars [file line column]
+  {:pre [(number? line)
+         (number? column)
+         (not-empty file)]}
+  (let [ast (-> file slurp ns-ast)
+        selected-sexpr (->> ast
+                           (top-level-form-index line column)
+                           (nth ast)
+                           nodes
+                           (filter (partial node-at-loc? line column))
+                           first)]
+    (set/intersection (->> selected-sexpr :env :locals keys set)
+                      (->> selected-sexpr
+                           nodes
+                           (filter #(= :local (:op %)))
+                           (map :form)
+                           set))))
+
+(defn- find-unbound-reply [{:keys [transport file line column] :as msg}]
   (try
-    (let [unbound (find-unbound-vars ns)]
+    (let [unbound (find-unbound-vars file line column)]
       (transport/send transport
                       (response-for msg
                                     :unbound (str/join " " unbound)
@@ -27,8 +50,10 @@
  #'wrap-find-unbound
  {:handles
   {"find-unbound"
-   {:doc "Finds unbound vars in the input ns."
-    :requires {"ns" "The ns containing unbound vars"}
+   {:doc "Finds vars which would be unbound when the nearest enclosing form is moved to be a top level form."
+    :requires {"file" "Path to the file in the project to work on"
+               "line" "The line number defining the point to find the 'nearest enclosing form'"
+               "column" "The column number defining the point to find the 'nearest enclosing form'"}
     :returns {"status" "done"
               "error" "an error message, intended to be displayed to the user."
               "unbound" "space separated list of unbound vars"}}}})

--- a/src/refactor_nrepl/util.clj
+++ b/src/refactor_nrepl/util.clj
@@ -1,5 +1,6 @@
 (ns refactor-nrepl.util
   (:require [clojure.tools.namespace.find :refer [find-clojure-sources-in-dir]]
+            [clojure.tools.analyzer.ast :refer :all]
             [clojure.tools.namespace.parse :refer [read-ns-decl]])
   (:import java.io.PushbackReader))
 
@@ -11,3 +12,18 @@
 
 (defn list-project-clj-files [dir]
   (find-clojure-sources-in-dir (java.io.File. dir)))
+
+(defn node-at-loc? [loc-line loc-column node]
+  (let [env (:env node)]
+    (and (= loc-line (:line env))
+         (>= loc-column (:column env))
+         (<= loc-column (:end-column env)))))
+
+(defn top-level-form-index
+  [line column ns-ast]
+  (->> ns-ast
+       (map-indexed #(vector %1 (->> %2
+                                     nodes
+                                     (some (partial node-at-loc? line column)))))
+       (filter #(second %))
+       ffirst))

--- a/test/refactor_nrepl/integration_tests.clj
+++ b/test/refactor_nrepl/integration_tests.clj
@@ -5,7 +5,7 @@
             [me.raynes.fs :as fs]
             [refactor-nrepl find-unbound find_symbol
              [client :refer [connect find-usages remove-debug-invocations
-                             rename-symbol resolve-missing]]]
+                             rename-symbol resolve-missing find-unbound]]]
             refactor-nrepl.ns.resolve-missing)
   (:import java.io.File))
 
@@ -199,11 +199,11 @@
         result (remove keyword? response)]
     (is (= 2 (count result)) (format "expected 2 results but got %d" (count result)))))
 
-;; commented out because the other tests depend on the classpath being
-;; in a pristine condition
-;; (deftest test-find-unbound-vars
-;;   (let [transport (connect :port 7777)]
-;;     (is (= (find-unbound :transport transport :ns "refactor-nrepl.integration-tests")
-;;            '#{}))
-;;     (is (= (find-unbound :transport transport :ns "resources.test-unbound")
-;;            '#{s sep}))))
+(deftest test-find-unbound-vars
+  (let [tmp-dir (create-test-project)
+        five-file (str tmp-dir "/src/com/example/five.clj")
+        transport (connect :port 7777)]
+    (is (= (find-unbound :transport transport :file five-file :line 12 :column 6)
+           '#{s}))
+    (is (= (find-unbound :transport transport :file five-file :line 13 :column 13)
+           '#{s sep}))))


### PR DESCRIPTION
- refactors bits of find symbols to reuse in find unbound
- rework of extract fn, rel to clojure-emacs/clj-refactor.el#103 and
  #15
  - analyzes a s-expression child of the top level form to figure out
    what would be unbound if the s-expression was top level form
  - does not expect a broken ns to analyze