### PR TITLE
Add op warm-ast-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ Return valus `status` of `done` and `unbound` which is a  list of unbound vars, 
 
 This op returns, `version`, which is the current version of this project.
 
+### warm-ast-cache
+
+This eagerly builds, and caches, ASTs for all clojure files in the project.  Returns `status` `done` on success.
+
 ### Errors
 
 The middleware returns errors under one of two keys: `:error` or
@@ -236,6 +240,8 @@ Or alternitavely run
 build.sh cleans, runs source-deps with the right parameters, runs the tests and then runs the provided lein target.
 
 ## Changelog
+
+* Add `warm-ast-cache` op for eagerly building, and caching, ASTs of project files
 
 ### 1.0.5
 

--- a/src/refactor_nrepl/analyzer.clj
+++ b/src/refactor_nrepl/analyzer.clj
@@ -3,11 +3,9 @@
   (:require [clojure.java.io :as io]
             [clojure.tools.analyzer :as ana]
             [clojure.tools.analyzer.jvm :as aj]
-            [clojure.tools.analyzer.passes :refer [schedule]]
             [clojure.tools.analyzer.jvm.utils :as ajutils]
-            [clojure.tools.analyzer.passes.emit-form :as emit-form]
-            [clojure.tools.analyzer.passes.jvm.validate :refer [validate]]
-            [clojure.tools.namespace.parse :refer [read-ns-decl]])
+            [clojure.tools.namespace.parse :refer [read-ns-decl]]
+            [refactor-nrepl.util :as util])
   (:import java.io.PushbackReader))
 
 ;;; The structure here is {ns {content-hash ast}}
@@ -74,3 +72,7 @@
     (catch Exception ex
       (throw (IllegalStateException.
               (str (first (parse-ns file-content)) " is in a bad state!"))))))
+
+(defn warm-ast-cache []
+  (doseq [f (util/list-project-clj-files ".")]
+    (ns-ast (slurp f))))

--- a/src/refactor_nrepl/middleware.clj
+++ b/src/refactor_nrepl/middleware.clj
@@ -5,6 +5,7 @@
              [misc :refer [response-for]]
              [transport :as transport]]
             [refactor-nrepl
+             [analyzer :refer [warm-ast-cache]]
              [artifacts :refer [artifact-list artifact-versions hotload-dependency]]
              [config :refer [configure]]
              [find-symbol :refer [create-result-alist find-debug-fns find-symbol]]
@@ -69,6 +70,9 @@
 (defn- version-reply [{:keys [transport] :as msg}]
   (reply transport msg :status :done :version (plugin/version)))
 
+(defn- warm-ast-cache-reply [{:keys [transport] :as msg}]
+  (reply transport msg :status (do (warm-ast-cache) :done)))
+
 (def refactor-nrepl-ops
   {"resolve-missing" resolve-missing-reply
    "find-debug-fns" find-debug-fns-reply
@@ -79,6 +83,7 @@
    "clean-ns" clean-ns-reply
    "configure" config-reply
    "version" version-reply
+   "warm-ast-cache" warm-ast-cache-reply
    "find-unbound" find-unbound-reply})
 
 (defn wrap-refactor


### PR DESCRIPTION
This is a dedicated op for warming the ast cache.  This removes the need
for overloading `find-symbol` to also pre-build the cache.