### PR TITLE
Add op stubs-for-interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,21 @@ This op requires `file` which is the name of the file to work on and well as `li
 
 Return valus `status` of `done` and `unbound` which is a  list of unbound vars, or `error` when something went wrong.
 
+### stubs-for-interface
+
+`stubs-for-interface` takes a single input `interface` which is a fully qualified symbol which resolves to either an interface or protocol.
+
+The return value is `edn` and looks like this:
+
+```clj
+user> (stubs-for-interface {:interface "java.lang.Iterable"})
+({:parameter-list "[^java.util.function.Consumer arg0]", :name "forEach"}
+ {:parameter-list "[]", :name "iterator"}
+ {:parameter-list "[]", :name "spliterator"})
+```
+
+The intended use-case for `stubs-for-interface` is to provide enough info to create skeleton implementations when implementing e.g. an interface in a defrecord.
+
 ### version
 
 This op returns, `version`, which is the current version of this project.
@@ -231,7 +246,7 @@ to clojars:
 
 `lein with-profile plugin.mranderson/config deploy clojars`
 
-Or alternitavely run
+Or alternatively run
 
 `./build.sh install`
 
@@ -241,6 +256,7 @@ build.sh cleans, runs source-deps with the right parameters, runs the tests and 
 
 ## Changelog
 
+* Add `stubs-for-interface` for creating skeleton interface implementations
 * Add `warm-ast-cache` op for eagerly building, and caching, ASTs of project files
 
 ### 1.0.5

--- a/project.clj
+++ b/project.clj
@@ -22,6 +22,7 @@
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha6"]]}
              :dev {:plugins [[jonase/eastwood "0.2.0"]]
                    :dependencies [[me.raynes/fs "1.4.6"]]
+                   :java-source-paths ["test/java"]
                    :resource-paths ["test/resources"
                                     "test/resources/testproject/src"]
                    :repositories [["snapshots" "http://oss.sonatype.org/content/repositories/snapshots"]]}})

--- a/src/refactor_nrepl/middleware.clj
+++ b/src/refactor_nrepl/middleware.clj
@@ -10,7 +10,8 @@
              [config :refer [configure]]
              [find-symbol :refer [create-result-alist find-debug-fns find-symbol]]
              [find-unbound :refer [find-unbound-vars]]
-             [plugin :as plugin]]
+             [plugin :as plugin]
+             [stubs-for-interface :refer [stubs-for-interface]]]
             [refactor-nrepl.ns
              [clean-ns :refer [clean-ns]]
              [pprint :refer [pprint-ns]]
@@ -73,6 +74,10 @@
 (defn- warm-ast-cache-reply [{:keys [transport] :as msg}]
   (reply transport msg :status (do (warm-ast-cache) :done)))
 
+(defn- stubs-for-interface-reply [{:keys [transport] :as msg}]
+  (reply transport msg :status :done
+         :functions (pr-str (stubs-for-interface msg))))
+
 (def refactor-nrepl-ops
   {"resolve-missing" resolve-missing-reply
    "find-debug-fns" find-debug-fns-reply
@@ -84,7 +89,8 @@
    "configure" config-reply
    "version" version-reply
    "warm-ast-cache" warm-ast-cache-reply
-   "find-unbound" find-unbound-reply})
+   "find-unbound" find-unbound-reply
+   "stubs-for-interface" stubs-for-interface-reply})
 
 (defn wrap-refactor
   [handler]

--- a/src/refactor_nrepl/stubs_for_interface.clj
+++ b/src/refactor_nrepl/stubs_for_interface.clj
@@ -1,0 +1,70 @@
+(ns refactor-nrepl.stubs-for-interface
+  (:require [clojure
+             [reflect :as reflect]
+             [string :as str]]
+            [refactor-nrepl.ns.helpers :as ns-helpers]))
+
+(defn- format-type-hint
+  [t]
+  (let [type-hint (if (= (ns-helpers/prefix t) "java.lang")
+                    (str "^" (ns-helpers/suffix t))
+                    (str "^" t))]
+    ;; varargs
+    (if (.endsWith type-hint "<>")
+      (.replace type-hint "<>" "...")
+      type-hint)))
+
+(defn- format-parameter-name
+  ([index num-params]
+   (str "arg" (if (= num-params 1) "" index)))
+  ([index num-params protocol]
+   (if (= index 0) "this" (str "arg" index))))
+
+(defn- format-parameter-list
+  [parameter-types]
+  (if (seq parameter-types)
+    (let [params (map-indexed
+                  (fn [i t]
+                    (str (format-type-hint t) " "
+                         (format-parameter-name i (count parameter-types))))
+                  parameter-types)]
+      (str "[" (str/join " " params) "]"))
+    "[]"))
+
+(defn- declared-by?
+  "Does THING declare F or is it inherited?"
+  [thing f]
+  (= (ns-helpers/suffix thing)
+     (ns-helpers/suffix (:declaring-class f))))
+
+(defn- prune-reflect-result
+  [reflect-result thing]
+  (->> reflect-result
+       :members
+       (filter (partial declared-by? thing))
+       (map #(hash-map :name (str (:name %))
+                       :parameter-list (format-parameter-list
+                                        (:parameter-types %))))))
+
+(defn extract-fn-info
+  "Extracts information about the functions defined in the protocol.
+
+  The result should match the return value of clojure.reflect/reflect"
+  [info]
+  (for [arglist (:arglists info)
+        :let [params (map-indexed (fn [i a] (format-parameter-name
+                                             i (count arglist) :protocol))
+                                  arglist)]]
+    {:name (str (:name info))
+     :parameter-list (str "[" (str/join " " params) "]")}))
+
+(defn stubs-for-interface
+  "Get functions defined by protocol / interface."
+  [{:keys [interface]}]
+  (try
+    (if-let [v (-> interface symbol resolve)]
+      (if (instance? java.lang.Class v)
+        (prune-reflect-result (reflect/reflect v) v)
+        (mapcat extract-fn-info (-> v deref :sigs vals)))
+      (throw (IllegalArgumentException.
+              (str "Can't find interface " interface))))))

--- a/test/java/refactor/nrepl/MyInterface.java
+++ b/test/java/refactor/nrepl/MyInterface.java
@@ -1,0 +1,8 @@
+package refactor.nrepl;
+
+import java.util.List;
+
+interface MyInterface {
+    public String foo(String string);
+    public String foo(List<String> strings);
+}

--- a/test/refactor_nrepl/stubs_for_interface_test.clj
+++ b/test/refactor_nrepl/stubs_for_interface_test.clj
@@ -1,0 +1,31 @@
+(ns refactor-nrepl.stubs-for-interface-test
+  (:require [refactor-nrepl.stubs-for-interface :refer :all]
+            [clojure.reflect :as reflect]
+            [clojure.test :refer :all]))
+
+(defprotocol AProtocol
+  (regular-fn [arg1] "With a docstring")
+  (overloaded-fn [arg1] [arg1 arg2] [arg1 arg2 arg3] "With a docstring"))
+
+(deftest stubs-for-Runnable
+  (let [run (first (stubs-for-interface {:interface "java.lang.Runnable"}))]
+    (is (= (:parameter-list run) "[]"))
+    (is (= (:name run) "run"))))
+
+(deftest stubs-for-AProtocol
+  (let [my-protocol (stubs-for-interface
+                     {:interface "refactor-nrepl.stubs-for-interface-test/AProtocol"})
+        overloaded-fns (filter #(= (:name %) "overloaded-fn") my-protocol)]
+    (is (= (count my-protocol) 4))
+    (is (= (count overloaded-fns) 3))
+    (is (some #(= (:parameter-list %) "[this]") overloaded-fns))
+    (is (some #(= (:parameter-list %) "[this arg1]") overloaded-fns))
+    (is (some #(= (:parameter-list %) "[this arg1 arg2]") overloaded-fns))))
+
+(deftest stubs-for-MyInterface
+  (let [my-interface (stubs-for-interface
+                      {:interface "refactor.nrepl.MyInterface"})]
+    (is (= (count my-interface) 2))
+    (testing "Removal of java.lang prefix"
+      (is (some #(= (:parameter-list %) "[^String arg]") my-interface)))
+    (is (some #(= (:parameter-list %) "[^java.util.List arg]") my-interface))))


### PR DESCRIPTION
This returns enough information to create stub implementations of
protocols and interfaces in the client.

Specifically it returns the name of functions to implement as well as
the parameter list.

https://github.com/clojure-emacs/clj-refactor.el/pull/148