### PR TITLE
Add op extract-definition 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ pom.xml.asc
 \#*\#
 .\#*
 install.cmd
+/install.sh
+/deploy.sh

--- a/README.md
+++ b/README.md
@@ -202,6 +202,32 @@ user> (stubs-for-interface {:interface "java.lang.Iterable"})
 
 The intended use-case for `stubs-for-interface` is to provide enough info to create skeleton implementations when implementing e.g. an interface in a defrecord.
 
+### extract-definition
+
+`extract-definition` is based on `find-symbol` so it takes the same input values.  The return value, `definition` is a string of edn which looks like this:
+
+```clj
+{:definition {:line-beg 4
+              :line-end 4
+              :col-beg 9
+              :col-end 21
+              :name \"another-val\"
+              :file \"core.clj\"
+              :match \"(let [another-val 321]\"
+                            :definition \"321\"}
+ :occurrences ({:match \"(println my-constant my-constant another-val)))\"
+                :file \"core.clj\"
+                :name \"another-val\"
+                :col-end 50
+                :col-beg 38
+                :line-end 5
+                :line-beg 5})}
+```
+
+The key `:definition` contains information about the defining form, so the client can delete it.
+
+The key `:occurrences` is a seq of all occurrences of the symbol which need to be inlined.  This means the definition itself is excluded to avoid any special handling by the client.
+
 ### version
 
 This op returns, `version`, which is the current version of this project.
@@ -256,6 +282,7 @@ build.sh cleans, runs source-deps with the right parameters, runs the tests and 
 
 ## Changelog
 
+* Add `extract-definition` which returns enough information to the clien to afford inlining of defs defns and let-bound vars.
 * Add `stubs-for-interface` for creating skeleton interface implementations
 * Add `warm-ast-cache` op for eagerly building, and caching, ASTs of project files
 

--- a/src/refactor_nrepl/extract_definition.clj
+++ b/src/refactor_nrepl/extract_definition.clj
@@ -1,0 +1,92 @@
+(ns refactor-nrepl.extract-definition
+  (:require [clojure.string :as str]
+            [refactor-nrepl
+             [find-symbol :refer [create-result-alist find-symbol]]
+             [util :refer [get-enclosing-sexp]]]
+            [refactor-nrepl.ns.helpers :refer [suffix]]
+            [refactor-nrepl.util :refer [get-enclosing-sexp get-next-sexp]])
+  (:import [java.io PushbackReader StringReader]
+           java.util.regex.Pattern))
+
+(defn- occurrence-to-map
+  [occurrence]
+  (zipmap (take-nth 2 occurrence) (take-nth 2 (rest occurrence))))
+
+(defn- extract-definition-from-def
+  [^String sexp]
+  (let [def-form (read-string sexp)
+        docstring? (string? (nth def-form 2 :not-found))
+        def-of-literal? ()
+        sexp-sans-delimiters (.substring (str/trim sexp) 1 (dec (.length sexp)))
+        rdr (PushbackReader. (StringReader. sexp-sans-delimiters))]
+    (read rdr) ; discard def
+    (read rdr) ; discard var name
+    (when docstring?
+      (read rdr)) ; discard docstring
+    (str/trim (slurp rdr))))
+
+(defn- extract-definition-from-defn
+  [^String sexp]
+  (let [form (read-string sexp)
+        fn-name (str (second form))]
+    (-> sexp
+        (.replaceFirst (if (re-matcher #"defn-" sexp) "defn-" "defn") "fn")
+        (.replaceFirst (str "\\s*" (Pattern/quote fn-name)) ""))))
+
+(defn- extract-def-from-binding-vector
+  [^String bindings ^String var-name]
+  (let [i (.indexOf bindings var-name)
+        next-form-with-trailing-garb (str/trim
+                                      (.substring bindings (+ i (.length var-name))))
+        next-form (read-string next-form-with-trailing-garb)]
+    (if (re-find #"[\({\[]" (str next-form))
+      (get-next-sexp next-form-with-trailing-garb)
+      (str next-form))))
+
+(defn- -extract-definition
+  [{:keys [match file line-beg col-beg name]}]
+  (let [literal-sexp (get-enclosing-sexp (slurp file) line-beg col-beg)
+        form (read-string literal-sexp)]
+    (.replaceAll
+     (case (first form)
+       def (extract-definition-from-def literal-sexp)
+       def- (extract-definition-from-def literal-sexp)
+       defn (extract-definition-from-defn literal-sexp)
+       defn- (extract-definition-from-defn literal-sexp)
+       (extract-def-from-binding-vector literal-sexp name))
+     "\r" "")))
+
+(defn- def-form?
+  "Is FORM a def or defn?"
+  [form]
+  (if (and (or (list? form) (instance? clojure.lang.Cons form)) (seq form))
+    (case (first form)
+      def true
+      def- true
+      defn true
+      defn- true
+      false)))
+
+(defn- def?
+  "Is the OCCURRENCE the defining form?"
+  [{:keys [file name col-beg line-beg] :as msg}]
+  (let [form (read-string (get-enclosing-sexp (slurp file) line-beg col-beg))
+        name (symbol (suffix (read-string name)))]
+    (if (def-form? form)
+      (= (second form) name)
+      (when (vector? form)
+        (> (count (drop-while #(not= % name) form)) 1)))))
+
+(defn extract-definition
+  "Returns the definition of SYMBOL to facilitate inlining."
+  [msg]
+  (let [occurrences (some->> msg
+                             find-symbol
+                             (map #(apply create-result-alist %))
+                             (map occurrence-to-map))]
+    (when-let [definition-occurrence (some->> occurrences
+                                              (filter def?)
+                                              first)]
+      {:definition (merge {:definition (-extract-definition definition-occurrence)}
+                          definition-occurrence)
+       :occurrences (remove #(= % definition-occurrence) occurrences)})))

--- a/src/refactor_nrepl/middleware.clj
+++ b/src/refactor_nrepl/middleware.clj
@@ -8,6 +8,7 @@
              [analyzer :refer [warm-ast-cache]]
              [artifacts :refer [artifact-list artifact-versions hotload-dependency]]
              [config :refer [configure]]
+             [extract-definition :refer [extract-definition]]
              [find-symbol :refer [create-result-alist find-debug-fns find-symbol]]
              [find-unbound :refer [find-unbound-vars]]
              [plugin :as plugin]
@@ -78,6 +79,9 @@
   (reply transport msg :status :done
          :functions (pr-str (stubs-for-interface msg))))
 
+(defn- extract-definition-reply [{:keys [transport] :as msg}]
+  (reply transport msg :status :done :definition (pr-str (extract-definition msg))))
+
 (def refactor-nrepl-ops
   {"resolve-missing" resolve-missing-reply
    "find-debug-fns" find-debug-fns-reply
@@ -90,6 +94,7 @@
    "version" version-reply
    "warm-ast-cache" warm-ast-cache-reply
    "find-unbound" find-unbound-reply
+   "extract-definition" extract-definition-reply
    "stubs-for-interface" stubs-for-interface-reply})
 
 (defn wrap-refactor

--- a/src/refactor_nrepl/util.clj
+++ b/src/refactor_nrepl/util.clj
@@ -108,3 +108,76 @@
       (if-let [forms (:raw-forms node)]
         (some #(re-find pattern %) (map (comp str read-first-form) forms))
         (= sexp-sans-comments-and-meta (read-first-form (:form node)))))))
+
+(defn- search-sexp-boundary
+  "Searches sexp open or close paren of given depth.
+
+   Depth depends on the passed in pred.
+   Searches forward by default if backwards passed in searches backwards.
+
+   If pred is (partial = 0) returns the index of the closing paren of the first s-expression. If pred is (partial < 0) searches for the opening paren of the first sexp."
+  ([pred s]
+   (search-sexp-boundary pred nil s))
+  ([pred backwards s]
+   (let [open #{\[ \{ \(}
+         close #{\] \} \)}
+         s (if backwards (reverse s) s)
+         prev-char-fn (if backwards inc dec)]
+     (if (some (set/union open close) s)
+       (loop [chars s
+              cnt 0
+              op-cl 0
+              ready false]
+         (let [[ch & chars] chars
+               char-index (dec cnt)]
+           (cond (and ready (pred op-cl))
+                 (if (and (= (nth s char-index) \{)
+                          (not= 0 char-index)
+                          (= (nth s (prev-char-fn char-index)) \#))
+                   (prev-char-fn char-index)
+                   char-index)
+
+                 (open ch)
+                 (recur chars (inc cnt) (inc op-cl) true)
+
+                 (close ch)
+                 (recur chars (inc cnt) (dec op-cl) true)
+
+                 :else
+                 (recur chars (inc cnt) op-cl ready))))
+       0))))
+
+(defn- cut-sexp [code sexp-start sexp-end]
+  (if (= sexp-start sexp-end)
+    ""
+    (.substring code sexp-start (inc sexp-end))))
+
+(defn get-next-sexp [code]
+  (let [trimmed-code (str/trim code)
+        sexp-start (search-sexp-boundary (partial < 0) trimmed-code)
+        sexp-end (search-sexp-boundary (partial = 0) trimmed-code)]
+    (cut-sexp trimmed-code sexp-start sexp-end)))
+
+(defn get-enclosing-sexp
+  "Extracts the sexp enclosing point at LINE and COLUMN in FILE-CONTENT.
+  A string is not treated as a sexp by this function.
+  Line is indexed from 1, and column is indexed from 0 (this is how
+  emacs does it)."
+  [file-content line column]
+  (let [lines (str/split-lines file-content)
+        line-index (dec line)
+        char-count-for-lines (->> lines
+                                  (take line-index)
+                                  (map count)
+                                  (reduce + line-index))
+        content-to-point (-> char-count-for-lines
+                             (+ column)
+                             (take file-content))
+        sexp-start (->> content-to-point
+                        (search-sexp-boundary (partial < 0) :backwards)
+                        (- (count content-to-point) 1))
+        content-from-sexp (.substring file-content sexp-start)
+        sexp-end (+ sexp-start
+                    (->> content-from-sexp
+                         (search-sexp-boundary (partial = 0))))]
+    (cut-sexp file-content sexp-start sexp-end)))

--- a/test/refactor_nrepl/extract_definition_test.clj
+++ b/test/refactor_nrepl/extract_definition_test.clj
@@ -1,0 +1,89 @@
+(ns refactor-nrepl.extract-definition-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
+            [refactor-nrepl.extract-definition :refer :all]))
+
+(defn- -extract-definition
+  [name line col]
+  (get-in (extract-definition
+           {:file (.getAbsolutePath (io/file "test/resources/extract_definition.clj"))
+            :ns "resources.extract-definition"
+            :line line
+            :column col
+            :name name
+            :dir "test/resources"})
+          [:definition :definition]))
+
+(deftest extracts-private-function-definitition-with-docstring-and-meta
+  (is (= (-extract-definition "private-function-definition-with-docstring-and-meta" 29 42)
+         "(fn
+  \"docstring\"
+  [foo]
+  {:pre [(not (nil? foo))]}
+  (do
+    (+ 1 2) ; discard this value
+    :return))")))
+
+(deftest extracts-private-function-definitition-with-docstring-no-meta
+  (is (= (-extract-definition "private-function-definition-with-docstring-no-meta" 30 37)
+         "(fn
+  \"docstring\"
+  [foo]
+  (do
+    (+ 1 2) ; discard this value
+    :value))")))
+
+(deftest extracts-private-function-definitition-without-docstring-and-meta
+  (is (= (-extract-definition "private-function-definition-witout-docstring-and-meta" 31 37)
+         "(fn
+  [foo]
+  (do
+    (+ 1 2) ; discard this value
+    :val))")))
+
+(deftest extracts-private-var-no-docstring
+  (is (= (-extract-definition "private-var-no-docstring" 34 2)
+         ":value")))
+
+(deftest extracts-private-var-no-docstring-no-value
+  (is (= (-extract-definition "private-var-no-docstring-no-value" 35 2)
+         "")))
+
+(deftest extracts-private-var-with-docstring
+  (is (= (-extract-definition "private-var-with-docstring" 36 2)
+         ":value")))
+
+(deftest extracts-var-with-docstringand-value
+  (is (= (-extract-definition "var-with-docstring-and-value" 37 2)
+         ":value")))
+
+(deftest extracts-let-bound
+  (is (= (-extract-definition "let-bound" 42 13)
+         "(+ 1 2)")))
+
+(deftest extracts-let-bound-multi-line
+  (is (= (-extract-definition "let-bound-multi-line" 42 28)
+         "(+ 1 (* 3 2)
+                                (- 77 32) ; eol comment
+                                (/ 9 3))")))
+
+(deftest extracts-if-let-bound
+  (is (= (-extract-definition "if-let-bound" 44 13)
+         "(+ 11 17)")))
+
+(deftest returns-meta-data
+  (let [res (extract-definition
+             {:file (.getAbsolutePath (io/file "test/resources/extract_definition.clj"))
+              :ns "resources.extract-definition"
+              :line 44
+              :column 13
+              :name "if-let-bound"
+              :dir "."})]
+    (is (= (count (:occurrences res)) 1))
+    (let [ks (keys (first (:occurrences res)))
+          def-ks (keys (:definition res))]
+      (is (= (count ks) 7))
+      (is (every? #{:line-beg :line-end :col-beg :col-end :name :file :match} ks))
+
+      (is (= (count def-ks) 8))
+      (is (every? (conj (set ks) :definition) def-ks)))))

--- a/test/refactor_nrepl/test_artifacts.clj
+++ b/test/refactor_nrepl/test_artifacts.clj
@@ -14,6 +14,7 @@
                            edn/read-string))
 
 (deftest creates-a-map-of-artifacts
+  (reset! artifacts/artifacts {})
   (with-redefs
     [artifacts/get-artifacts-from-clojars! (constantly clojars-artifacts)
      artifacts/get-all-clj-artifacts! (constantly clojure-artifacts)

--- a/test/refactor_nrepl/util_test.clj
+++ b/test/refactor_nrepl/util_test.clj
@@ -3,8 +3,8 @@
             [clojure.test :refer :all]))
 
 (def file-content (slurp "test/resources/testproject/src/com/example/sexp_test.clj"))
-(def weird-file-content ";; some weird file
-;; not even clojure
+  (def weird-file-content ";; some weird file
+  ;; not even clojure
 ;; perhaps? no parens!")
 (def binding-location [4 10])
 (def funcall-location [7 8])
@@ -13,11 +13,10 @@
 (def weird-location [2 5])
 
 (deftest get-enclosing-sexp-test
-  (is (= (apply get-enclosing-sexp file-content binding-location)
-         "[some :bindings
-        more :bindings]"))
-  (is (= (apply get-enclosing-sexp file-content funcall-location)
-         "(println #{some}
+  (is (= "[some :bindings
+        more :bindings]"
+         (apply get-enclosing-sexp file-content binding-location)))
+  (is (= "(println #{some}
              ;; helpful comment
              (prn {\"foo\" {:qux [#{more}]}}))"))
   (is (= (apply get-enclosing-sexp file-content set-location) "#{more}"))

--- a/test/refactor_nrepl/util_test.clj
+++ b/test/refactor_nrepl/util_test.clj
@@ -6,6 +6,10 @@
   (def weird-file-content ";; some weird file
   ;; not even clojure
 ;; perhaps? no parens!")
+  (def file-content-with-set ";; with set
+  #{foo bar baz}
+  ;; some other stuff
+(foobar baz)")
 (def binding-location [4 10])
 (def funcall-location [7 8])
 (def set-location [8 35])
@@ -21,4 +25,6 @@
              (prn {\"foo\" {:qux [#{more}]}}))"))
   (is (= (apply get-enclosing-sexp file-content set-location) "#{more}"))
   (is (= (apply get-enclosing-sexp file-content map-location) "{:qux [#{more}]}"))
-  (is (= (apply get-enclosing-sexp weird-file-content weird-location) "")))
+  (is (= (apply get-enclosing-sexp weird-file-content weird-location) ""))
+  (is (= (get-next-sexp weird-file-content) ""))
+  (is (= (get-next-sexp file-content-with-set) "#{foo bar baz}")))

--- a/test/resources/extract_definition.clj
+++ b/test/resources/extract_definition.clj
@@ -1,0 +1,45 @@
+(ns resources.extract-definition)
+
+(defn- private-function-definition-with-docstring-and-meta
+  "docstring"
+  [foo]
+  {:pre [(not (nil? foo))]}
+  (do
+    (+ 1 2) ; discard this value
+    :return))
+
+(defn- private-function-definition-with-docstring-no-meta
+  "docstring"
+  [foo]
+  (do
+    (+ 1 2) ; discard this value
+    :value))
+
+(defn- private-function-definition-witout-docstring-and-meta
+  [foo]
+  (do
+    (+ 1 2) ; discard this value
+    :val))
+
+(def ^:private private-var-no-docstring :value)
+(def ^:private private-var-no-docstring-no-value)
+(def ^:private private-var-with-docstring "Docstring 1" :value)
+(def var-with-docstring-and-value "Docstring 2" :value)
+
+(private-function-definition-with-docstring-and-meta :foo)
+(private-function-definition-with-docstring-no-meta :foo)
+(private-function-definition-witout-docstring-and-meta :foo)
+
+(do
+  private-var-no-docstring
+  private-var-no-docstring-no-value
+  private-var-with-docstring
+  var-with-docstring-and-value
+  (let [let-bound (+ 1 2)
+        let-bound-multi-line (+ 1 (* 3 2)
+                                (- 77 32) ; eol comment
+                                (/ 9 3))]
+    (+ let-bound let-bound-multi-line)
+    (if-let [if-let-bound (+ 11 17)]
+      if-let-bound
+      :bar)))


### PR DESCRIPTION
Given the same input as `find-symbol` `extract-definition` will extract
one of the following definitions:

- let-bound var
- def
- defn

The implementation does not use the reader to extract the definition so
any metadata or comments in the definition body are preserved