### PR TITLE
Add rename-file-or-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,18 @@ This op returns, `version`, which is the current version of this project.
 
 This eagerly builds, and caches, ASTs for all clojure files in the project.  Returns `status` `done` on success.
 
+### rename-file-or-dir
+
+The `rename-file-or-dir` op takes an `old-path` and a `new-path` which are paths to a file or directory.
+
+If `old-path` is a directory, all files, including any non-clj files, are moved to `new-path`.
+
+The op returns `touched` which is a list of all files that were affected by the move, and needs to be visited by the client to indent the updated ns form while we await proper pretty printing support in the middleware.
+
+This op can cause serious havoc if it crashes midway through the
+refactoring.  I recommend not running it without first creating a
+restore point in your version control system.
+
 ### Errors
 
 The middleware returns errors under one of two keys: `:error` or
@@ -282,6 +294,7 @@ build.sh cleans, runs source-deps with the right parameters, runs the tests and 
 
 ## Changelog
 
+* Add `rename-file-or-dir` which returns a file or a directory of clj files.
 * Add `extract-definition` which returns enough information to the clien to afford inlining of defs defns and let-bound vars.
 * Add `stubs-for-interface` for creating skeleton interface implementations
 * Add `warm-ast-cache` op for eagerly building, and caching, ASTs of project files

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,8 @@
                  ^:source-dep [org.clojure/tools.analyzer.jvm "0.6.6"]
                  ^:source-dep [org.clojure/tools.namespace "0.2.7"]
                  ^:source-dep [org.clojure/tools.reader "0.8.12"]
-                 ^:source-dep [org.clojure/java.classpath "0.2.2"]]
+                 ^:source-dep [org.clojure/java.classpath "0.2.2"]
+                 ^:source-dep [me.raynes/fs "1.4.6"]]
   :plugins [[thomasa/mranderson "0.4.0"]]
   :filespecs [{:type :bytes :path "refactor-nrepl/refactor-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
   :profiles {:provided {:dependencies [[cider/cider-nrepl "0.8.2"]]}
@@ -21,7 +22,7 @@
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0-beta3"]]}
              :dev {:plugins [[jonase/eastwood "0.2.0"]]
                    :dependencies [[org.clojure/clojure "1.7.0-beta3"]
-                                  [me.raynes/fs "1.4.6"]]
+                                  [commons-io/commons-io "2.4"]]
                    :java-source-paths ["test/java"]
                    :resource-paths ["test/resources"
                                     "test/resources/testproject/src"]

--- a/src/refactor_nrepl/middleware.clj
+++ b/src/refactor_nrepl/middleware.clj
@@ -12,6 +12,7 @@
              [find-symbol :refer [create-result-alist find-debug-fns find-symbol]]
              [find-unbound :refer [find-unbound-vars]]
              [plugin :as plugin]
+             [rename-file-or-dir :refer [rename-file-or-dir]]
              [stubs-for-interface :refer [stubs-for-interface]]]
             [refactor-nrepl.ns
              [clean-ns :refer [clean-ns]]
@@ -66,7 +67,7 @@
 (defn- find-unbound-reply [{:keys [transport] :as msg}]
   (reply transport msg :unbound (find-unbound-vars msg) :status :done))
 
-(defn- config-reply [{:keys [transport] :as msg}]
+(defn config-reply [{:keys [transport opts] :as msg}]
   (reply transport msg :status (and (configure msg) :done)))
 
 (defn- version-reply [{:keys [transport] :as msg}]
@@ -82,6 +83,10 @@
 (defn- extract-definition-reply [{:keys [transport] :as msg}]
   (reply transport msg :status :done :definition (pr-str (extract-definition msg))))
 
+(defn- rename-file-or-dir-reply [{:keys [transport old-path new-path] :as msg}]
+  (reply transport msg :touched (rename-file-or-dir old-path new-path)
+         :status :done))
+
 (def refactor-nrepl-ops
   {"resolve-missing" resolve-missing-reply
    "find-debug-fns" find-debug-fns-reply
@@ -95,6 +100,7 @@
    "warm-ast-cache" warm-ast-cache-reply
    "find-unbound" find-unbound-reply
    "extract-definition" extract-definition-reply
+   "rename-file-or-dir" rename-file-or-dir-reply
    "stubs-for-interface" stubs-for-interface-reply})
 
 (defn wrap-refactor

--- a/src/refactor_nrepl/rename_file_or_dir.clj
+++ b/src/refactor_nrepl/rename_file_or_dir.clj
@@ -1,0 +1,215 @@
+(ns refactor-nrepl.rename-file-or-dir
+  (:require [clojure.java.classpath :as cp]
+            [clojure.string :as str]
+            [clojure.tools.namespace
+             [file :as file :refer [clojure-file?]]
+             [find :refer [find-clojure-sources-in-dir]]
+             [track :as tracker]]
+            [me.raynes.fs :as fs]
+            [refactor-nrepl.ns
+             [helpers :refer [file-content-sans-ns read-ns-form]]
+             [ns-parser :as ns-parser]
+             [pprint :refer [pprint-ns]]
+             [rebuild :as builder :refer [rebuild-ns-form]]]
+            [refactor-nrepl.util :refer [ns-from-string]])
+  (:import java.io.File
+           java.util.regex.Pattern))
+
+(declare -rename-file-or-dir)
+
+(defn- project-clj-files-on-classpath []
+  (let [dirs-on-cp (filter fs/directory? (cp/classpath))]
+    (mapcat find-clojure-sources-in-dir dirs-on-cp)))
+
+(defn- normalize-to-unix-path [path]
+  (if (.contains (System/getProperty "os.name") "Windows")
+    (.replaceAll path (Pattern/quote "\\") "/")
+    path))
+
+(defn- dirs-on-classpath []
+  (->> (cp/classpath) (filter fs/directory?)
+       (map #(.toLowerCase (.getAbsolutePath %)))))
+
+(defn- chop-src-dir-prefix
+  "Given a path cuts away the part matching a dir on classpath.
+
+  We use this as a crude way to find the source directories on the classpath."
+  [path]
+  (let [chop-prefix (fn [dir]
+                      (->> dir
+                           normalize-to-unix-path
+                           .toLowerCase
+                           Pattern/quote
+                           re-pattern
+                           (str/split path)
+                           second))
+        shortest (fn [acc val] (if (< (.length acc) (.length val)) acc val))]
+    (let [relative-paths (->> (dirs-on-classpath) (map chop-prefix) (remove nil?))]
+      (if-let [p (cond
+                   (= (count relative-paths) 1) (first relative-paths)
+                   (> (count relative-paths) 1) (reduce shortest relative-paths))]
+        (if (.startsWith p "/")
+          (.substring p 1)
+          p)
+        (throw (IllegalStateException. (str "Can't find src dir prefix for path " path)))))))
+
+(defn- path->ns
+  "Given an absolute file path to a non-existing file determine the
+  name of the ns."
+  [new-path]
+  (-> new-path normalize-to-unix-path chop-src-dir-prefix fs/path-ns))
+
+(defn- build-tracker []
+  (let [tracker (tracker/tracker)]
+    (file/add-files tracker (project-clj-files-on-classpath))))
+
+(defn- invert-map
+  "Creates a new map by turning the vals into keys and vice versa"
+  [m]
+  (reduce (fn [m kv] (assoc m (second kv) (first kv))) {} m))
+
+(defn- get-dependents
+  "Get the dependent files for ns from tracker."
+  [tracker my-ns]
+  (let [deps (my-ns (:dependents (:clojure.tools.namespace.track/deps tracker)))
+        ns-to-file-map (invert-map (:clojure.tools.namespace.file/filemap (build-tracker)))]
+    (map ns-to-file-map deps)))
+
+(defn update-ns-reference-in-libspec
+  [old-ns new-ns libspec]
+  (if (= (:ns libspec) old-ns)
+    (assoc libspec :ns new-ns)
+    libspec))
+
+(defn- update-libspecs
+  "Replaces any references old-ns with new-ns in all libspecs."
+  [libspecs old-ns new-ns]
+  (map (partial update-ns-reference-in-libspec old-ns new-ns) libspecs))
+
+(defn- replace-package-prefix
+  [old-prefix new-prefix class]
+  (if (.startsWith class old-prefix)
+    (str/replace class old-prefix new-prefix)
+    class))
+
+(defn- update-class-references
+  [classes old-ns new-ns]
+  (let [old-prefix (str/replace (str old-ns) "-" "_")
+        new-prefix (str/replace (str new-ns) "-" "_")]
+    (map (partial replace-package-prefix old-prefix new-prefix) classes)))
+
+(defn- create-new-ns-form
+  "Reads file and returns an updated ns."
+  [file old-ns new-ns]
+  (let [ns-form (read-ns-form file)
+        libspecs (ns-parser/get-libspecs ns-form)
+        classes (ns-parser/get-imports ns-form)
+        deps {:require (update-libspecs libspecs old-ns new-ns)
+              :import (update-class-references classes old-ns new-ns)}]
+    (pprint-ns (rebuild-ns-form ns-form deps))))
+
+(defn- update-file-content-sans-ns
+  "Any fully qualified references to old-ns has to be replaced with new-ns."
+  [file old-ns new-ns]
+  (let [old-prefix (str (str/replace old-ns "-" "_") "/")
+        new-prefix (str (str/replace new-ns "-" "_") "/")
+        old-ns-ref (str old-ns "/")
+        new-ns-ref (str new-ns "/")]
+    (-> file
+        slurp
+        file-content-sans-ns
+        (str/replace old-prefix new-prefix)
+        (str/replace old-ns-ref new-ns-ref))))
+
+(defn- update-dependent
+  "New content for a dependent file."
+  [file old-ns new-ns]
+  (str (create-new-ns-form file old-ns new-ns)
+       "\n"
+       (update-file-content-sans-ns file old-ns new-ns)))
+
+(defn- rename-file!
+  "Actually rename a file."
+  [old-path new-path]
+  (fs/mkdirs (fs/parent new-path))
+  (fs/rename old-path new-path)
+  (loop [dir (.getParentFile (File. old-path))]
+    (when (empty? (.listFiles dir))
+      (.delete dir)
+      (recur (.getParentFile dir)))))
+
+(defn- update-dependents!
+  "Actually write new content for dependents"
+  [new-dependents]
+  (doseq [[f content] new-dependents]
+    (spit f content)))
+
+(defn- update-ns!
+  "After moving some file to path update its ns to reflect new location."
+  [path old-ns]
+  (let [new-ns (path->ns path)
+        f (File. path)]
+    (->> new-ns
+         str
+         (str/replace-first (slurp f) (str old-ns))
+         (spit f))))
+
+(defn- rename-clj-file
+  "Move file from old to new, updating any dependents."
+  [old-path new-path]
+  (let [old-ns (ns-from-string (slurp old-path))
+        new-ns (path->ns new-path)
+        dependents (get-dependents (build-tracker) old-ns)
+        new-dependents (atom {})]
+    (doseq [f dependents]
+      (swap! new-dependents
+             assoc (.getAbsolutePath f) (update-dependent f old-ns new-ns)))
+    (rename-file! old-path new-path)
+    (update-ns! new-path old-ns)
+    (update-dependents! @new-dependents)
+    (into '() (map #(.getAbsolutePath %) dependents))))
+
+(defn- merge-paths
+  "Update path with new prefix when parent dir is moved"
+  [path old-parent new-parent]
+  (str/replace path old-parent new-parent))
+
+(defn- rename-dir [old-path new-path]
+  (let [old-path (normalize-to-unix-path old-path)
+        new-path (normalize-to-unix-path new-path)
+        old-path (if (.endsWith old-path "/") old-path (str old-path "/"))
+        new-path (if (.endsWith new-path "/") new-path (str new-path "/"))]
+    (flatten (for [f (file-seq (File. old-path))
+                   :when (not (fs/directory? f))
+                   :let [path (normalize-to-unix-path (.getAbsolutePath f))]]
+               (-rename-file-or-dir path (merge-paths path old-path new-path))))))
+
+(defn- -rename-file-or-dir [old-path new-path]
+  (let [affected-files  (if (fs/directory? old-path)
+                          (rename-dir old-path new-path)
+                          (if (file/clojure-file? (File. old-path))
+                            (rename-clj-file old-path new-path)
+                            (rename-file! old-path new-path)))]
+    (->> affected-files
+         flatten
+         distinct
+         (map normalize-to-unix-path)
+         (remove fs/directory?)
+         (filter fs/exists?)
+         doall)))
+
+(defn rename-file-or-dir
+  "Renames a file or dir updating all dependent files.
+
+  Returns a list of all files that were affected."
+  [old-path new-path]
+  {:pre [(not (str/blank? old-path))
+         (not (str/blank? new-path))
+         (or (fs/file? old-path) (fs/directory? old-path))]}
+  (binding [*print-length* nil]
+    (let [affected-files (-rename-file-or-dir old-path new-path)
+          affected-files (->> affected-files (filter fs/exists?)
+                              (remove fs/directory?))]
+      (if (fs/directory? new-path)
+        affected-files
+        (conj affected-files new-path)))))

--- a/test/refactor_nrepl/integration_tests.clj
+++ b/test/refactor_nrepl/integration_tests.clj
@@ -2,11 +2,11 @@
   (:require [clojure.java.io :as io]
             [clojure.test :refer :all]
             [clojure.tools.nrepl.server :as nrserver]
-            [me.raynes.fs :as fs]
             [refactor-nrepl middleware
              [client :refer :all]
              [plugin :as plugin]])
-  (:import java.io.File))
+  (:import java.io.File
+           org.apache.commons.io.FileUtils))
 
 (defn- create-temp-dir
   "Creates and returns a new temporary directory java.io.File."
@@ -19,9 +19,7 @@
 (defn create-test-project []
   (let [temp-dir (create-temp-dir "refactor-nrepl-test")
         orig-src (io/file "test/resources/testproject/src")]
-
-    (fs/copy-dir orig-src temp-dir)
-
+    (FileUtils/copyDirectoryToDirectory orig-src temp-dir)
     temp-dir))
 
 (defn start-up-repl-server []

--- a/test/refactor_nrepl/rename_file_or_dir_test.clj
+++ b/test/refactor_nrepl/rename_file_or_dir_test.clj
@@ -1,0 +1,149 @@
+(ns refactor-nrepl.rename-file-or-dir-test
+  (:require [clojure.test :refer :all]
+            [clojure.tools.namespace.parse :refer [read-ns-decl]]
+            [refactor-nrepl.rename-file-or-dir :refer :all]
+            [refactor-nrepl.ns.helpers
+             :refer
+             [file-content-sans-ns get-ns-component]])
+  (:import [java.io File PushbackReader StringReader]))
+
+(def from-file-path (.getAbsolutePath (File. "test/resources/testproject/src/com/move/ns_to_be_moved.clj")))
+(def to-file-path (.getAbsolutePath (File. "test/resources/testproject/src/com/move/moved_ns.clj")))
+(def from-dir-path (.getAbsolutePath (File. "test/resources/testproject/src/com/move/")))
+(def to-dir-path (.getAbsolutePath (File. "test/resources/testproject/src/com/moved/")))
+(def new-ns-ref "com.move.moved-ns/")
+(def old-ns-ref "com.move.ns-to-be-moved/")
+(def new-package-prefix "com.move.moved-ns/")
+(def old-package-prefix "com.move.ns_to_be_moved/")
+
+(def new-ns-ref-dir "com.moved.ns-to-be-moved/")
+(def old-ns-ref-dir "com.move.ns-to-be-moved/")
+(def new-package-prefix-dir "com.moved.ns-to-be-moved/")
+(def old-package-prefix-dir "com.move.ns_to_be_moved/")
+
+(deftest returns-list-of-affected-files
+  (with-redefs [refactor-nrepl.rename-file-or-dir/rename-file! (fn [old new])
+                refactor-nrepl.rename-file-or-dir/update-ns! (fn [path old-ns])
+                refactor-nrepl.rename-file-or-dir/update-dependents! (fn [dependents])]
+    (let [res (rename-file-or-dir from-file-path to-file-path)]
+      (is (or (list? res) (instance? clojure.lang.Cons res)))
+      (is (count res) 3))))
+
+(defn- ns-form-from-string
+  [file-content]
+  (if-let [ns-form (read-ns-decl (PushbackReader. (StringReader. file-content)))]
+    ns-form
+    (throw (IllegalArgumentException. "Malformed ns form!"))))
+
+(deftest replaces-ns-references-in-dependents
+  (let [dependents (atom [])]
+    (with-redefs [refactor-nrepl.rename-file-or-dir/rename-file! (fn [old new])
+                  refactor-nrepl.rename-file-or-dir/update-ns! (fn [path old-ns])
+                  refactor-nrepl.rename-file-or-dir/update-dependents!
+                  (fn [deps]
+                    (doseq [[f content] deps]
+                      (swap! dependents conj content)))]
+      (rename-file-or-dir from-file-path to-file-path)
+      (doseq [content @dependents
+              :let [ns-form (ns-form-from-string content)
+                    require-form (get-ns-component ns-form :require)
+                    required-ns (-> require-form second first)
+                    import-form (get-ns-component ns-form :import)
+                    imported-ns (-> import-form second first)]]
+        (is (= 'com.move.moved-ns required-ns))
+        (when imported-ns
+          (is (= 'com.move.moved_ns imported-ns)))))))
+
+(deftest replaces-fully-qualified-vars-in-dependents
+  (let [dependents (atom [])]
+    (with-redefs [refactor-nrepl.rename-file-or-dir/rename-file! (fn [old new])
+                  refactor-nrepl.rename-file-or-dir/update-ns! (fn [path old-ns])
+                  refactor-nrepl.rename-file-or-dir/update-dependents!
+                  (fn [deps]
+                    (doseq [[f content] deps]
+                      (swap! dependents conj [f content])))]
+      (rename-file-or-dir from-file-path to-file-path)
+      (doseq [[f content] @dependents
+              :when (.endsWith f "ns2.clj")]
+        (is (.contains content new-ns-ref))
+        (is (not (.contains content old-ns-ref)))
+
+        (is (.contains content new-package-prefix))
+        (is (not (.contains content old-package-prefix)))))))
+
+(deftest calls-rename-file!-on-the-right-file
+  (with-redefs [refactor-nrepl.rename-file-or-dir/rename-file!
+                (fn [old new]
+                  (is (= old from-file-path))
+                  (is (= new to-file-path)))
+                refactor-nrepl.rename-file-or-dir/update-ns! (fn [path old-ns])
+                refactor-nrepl.rename-file-or-dir/update-dependents! (fn [deps])]
+    (rename-file-or-dir from-file-path to-file-path)))
+
+(deftest replaces-ns-references-in-dependendents-when-moving-dirs
+  (let [dependents (atom [])]
+    (with-redefs [refactor-nrepl.rename-file-or-dir/rename-file! (fn [old new])
+                  refactor-nrepl.rename-file-or-dir/update-ns! (fn [path old-ns])
+
+                  refactor-nrepl.rename-file-or-dir/update-dependents!
+                  (fn [deps]
+                    (doseq [[f content] deps]
+                      (swap! dependents conj content)))]
+      (rename-file-or-dir from-dir-path to-dir-path)
+      (doseq [content @dependents
+              :let [ns-form (ns-form-from-string content)
+                    require-form (get-ns-component ns-form :require)
+                    required-ns (-> require-form second first)
+                    import-form (get-ns-component ns-form :import)
+                    imported-ns (-> import-form second first)]]
+        (is (= 'com.moved.ns-to-be-moved required-ns))
+        (when imported-ns
+          (is (= 'com.moved.ns_to_be_moved imported-ns)))))))
+
+(deftest returns-list-of-affected-files-when-moving-dirs
+  (with-redefs [refactor-nrepl.rename-file-or-dir/rename-file! (fn [old new])
+                refactor-nrepl.rename-file-or-dir/update-ns! (fn [path old-ns])
+                refactor-nrepl.rename-file-or-dir/update-dependents! (fn [dependents])]
+    (let [res (rename-file-or-dir from-dir-path to-dir-path)]
+      (is (seq? res))
+      (is (count res) 3))))
+
+(deftest replaces-fully-qualified-vars-in-dependents-when-moving-dirs
+  (let [dependents (atom [])]
+    (with-redefs [refactor-nrepl.rename-file-or-dir/rename-file! (fn [old new])
+                  refactor-nrepl.rename-file-or-dir/update-ns! (fn [path old-ns])
+                  refactor-nrepl.rename-file-or-dir/update-dependents!
+                  (fn [deps]
+                    (doseq [[f content] deps]
+                      (swap! dependents conj [f content])))]
+      (rename-file-or-dir from-dir-path to-dir-path)
+      (doseq [[f content] @dependents
+              :when (.endsWith f "ns2.clj")]
+        (is (.contains content new-ns-ref-dir))
+        (is (not (.contains content old-ns-ref-dir)))
+
+        (is (.contains content new-package-prefix-dir))
+        (is (not (.contains content old-package-prefix-dir)))))))
+
+(deftest calls-rename-file!-on-the-right-files-when-moving-dirs
+  (let [files (atom [])]
+    (with-redefs [refactor-nrepl.rename-file-or-dir/rename-file!
+                  (fn [old new]
+                    (swap! files conj [old new]))
+                  refactor-nrepl.rename-file-or-dir/update-ns! (fn [path old-ns])
+                  refactor-nrepl.rename-file-or-dir/update-dependents! (fn [deps])]
+      (rename-file-or-dir from-dir-path to-dir-path)
+      (is (= (count @files) 4))
+      (doseq [[old new] @files]
+        (is (.contains old "/move/"))
+        (is (.contains new "/moved/"))))))
+
+(deftest moves-any-non-clj-files-contained-in-the-dir
+  (let [files (atom [])]
+    (with-redefs [refactor-nrepl.rename-file-or-dir/rename-file!
+                  (fn [old new]
+                    (swap! files conj new))
+                  refactor-nrepl.rename-file-or-dir/update-ns! (fn [path old-ns])
+                  refactor-nrepl.rename-file-or-dir/update-dependents! (fn [deps])]
+      (rename-file-or-dir from-dir-path to-dir-path)
+      (is (first (filter #(.endsWith % "non_clj_file") @files))))))

--- a/test/resources/testproject/src/com/move/dependent_ns1.clj
+++ b/test/resources/testproject/src/com/move/dependent_ns1.clj
@@ -1,0 +1,10 @@
+(ns com.move.dependent-ns1
+  (:require [com.move.ns-to-be-moved
+             :refer [fn-to-be-moved macro-to-be-moved var-to-be-moved]])
+  (:import [com.move.ns_to_be_moved
+            TypeToBeMoved RecordToBeMoved]))
+
+(defn- use-some-publics []
+  (macro-to-be-moved
+   (fn-to-be-moved (TypeToBeMoved. :ok))
+   (fn-to-be-moved (RecordToBeMoved. :ok))))

--- a/test/resources/testproject/src/com/move/dependent_ns2.clj
+++ b/test/resources/testproject/src/com/move/dependent_ns2.clj
@@ -1,0 +1,9 @@
+(ns com.move.dependent-ns2
+  (:require [com.move.ns-to-be-moved :refer [fn-to-be-moved]]))
+
+(defn- use-some-private-stuff []
+  (#'com.move.ns-to-be-moved/private-fn-to-be-moved
+   com.move.ns_to_be_moved.RecordToBeMovedAndFullyQualified)
+  (#'com.move.ns-to-be-moved/private-fn-to-be-moved
+   com.move.ns_to_be_moved.TypeToBeMovedAndFullyQualified)
+  (fn-to-be-moved #'com.move.ns-to-be-moved/private-var-to-be-moved))

--- a/test/resources/testproject/src/com/move/non_clj_file
+++ b/test/resources/testproject/src/com/move/non_clj_file
@@ -1,0 +1,1 @@
+non clojure content

--- a/test/resources/testproject/src/com/move/ns_to_be_moved.clj
+++ b/test/resources/testproject/src/com/move/ns_to_be_moved.clj
@@ -1,0 +1,18 @@
+(ns com.move.ns-to-be-moved)
+
+(def var-to-be-moved)
+(def ^:private private-var-to-be-moved)
+
+(defmacro macro-to-be-moved [my-macro & body])
+
+(defn fn-to-be-moved [arg]
+  (println arg))
+
+(defn- private-fn-to-be-moved [arg]
+  (println arg))
+
+(deftype TypeToBeMoved [field])
+(deftype TypeToBeMovedAndFullyQualified [field])
+
+(defrecord RecordToBeMovedAndFullyQualified [field])
+(defrecord RecordToBeMoved [field])


### PR DESCRIPTION
This op is used to move a file or a directory of files.  If any clojure
files are affected by the move any dependent namespaces are updated.

Unlikely tools.namespace's move-ns this op also handles vectors written
in prefix notation as well as fully qualified references in the file
body itself referencing vars from the old namespace.

The return value of the op is a list of the file which were affected by
the move.  This list does not include any deleted files. These files all
have to be visited by the client to indent the changed ns form until we
get proper pretty printing support in the middleware.

This ops is quite slow because it does multiple passes over each file
but it's still orders of magnitude faster than doing this manually so
I'm not that worried about speed in this initial commit.