### PR TITLE
Bind clojure.tools.reader/*data-readers* to *data-readers*

### DIFF
--- a/src/refactor_nrepl/analyzer.clj
+++ b/src/refactor_nrepl/analyzer.clj
@@ -5,6 +5,7 @@
             [clojure.tools.analyzer.jvm :as aj]
             [clojure.tools.analyzer.jvm.utils :as ajutils]
             [clojure.tools.namespace.parse :refer [read-ns-decl]]
+            [clojure.tools.reader :as reader]
             [refactor-nrepl
              [util :as util]
              [config :as config]])
@@ -55,7 +56,8 @@
   [ns aliases]
   (when (ns-on-cp? ns)
     (binding [ana/macroexpand-1 noop-macroexpand-1
-              *file* (-> ns ajutils/ns-resource ajutils/source-path)]
+              *file* (-> ns ajutils/ns-resource ajutils/source-path)
+              reader/*data-readers* *data-readers*]
       (assoc-in (aj/analyze-ns ns) [0 :alias-info] aliases))))
 
 (defn- cachable-ast [file-content]


### PR DESCRIPTION
I've been having trouble today with refactor-nrepl telling me that many of my namespaces were "in a bad state". Printing the stacktrace showed me that the problem is that the analyser is not taking into account custom tagged-readers defined in `src/data_readers.clj`.

This pull request "fixes" this issue by binding `clojure.tools.reader/*data-readers*` to the current value of `clojure.core/*data-readers*`. I'm not sure if this is really the best way (or place) to solve the issue.

```java
clojure.lang.ExceptionInfo: No reader function for tag year-month {:column 66, :line 96, :file "file:/full/path/to/file/file.name.clj", :type :reader-exception}
	at clojure.core$ex_info.invoke(core.clj:4403)
	at deps.toolsreader.v0v8v12.clojure.tools.reader.reader_types$reader_error.doInvoke(reader_types.clj:336)
	at clojure.lang.RestFn.invoke(RestFn.java:439)
	at deps.toolsreader.v0v8v12.clojure.tools.reader$read_tagged.invoke(reader.clj:674)
	at deps.toolsreader.v0v8v12.clojure.tools.reader$read_dispatch.invoke(reader.clj:58)
	at deps.toolsreader.v0v8v12.clojure.tools.reader$read_delimited.invoke(reader.clj:161)
	at deps.toolsreader.v0v8v12.clojure.tools.reader$read_list.invoke(reader.clj:173)
	at deps.toolsreader.v0v8v12.clojure.tools.reader$read_delimited.invoke(reader.clj:161)
	at deps.toolsreader.v0v8v12.clojure.tools.reader$read_vector.invoke(reader.clj:192)
	at deps.toolsreader.v0v8v12.clojure.tools.reader$read_delimited.invoke(reader.clj:161)
	at deps.toolsreader.v0v8v12.clojure.tools.reader$read_list.invoke(reader.clj:173)
	at deps.toolsreader.v0v8v12.clojure.tools.reader$read_delimited.invoke(reader.clj:161)
	at deps.toolsreader.v0v8v12.clojure.tools.reader$read_list.invoke(reader.clj:173)
	at deps.toolsreader.v0v8v12.clojure.tools.reader$read.invoke(reader.clj:748)
	at deps.toolsreader.v0v8v12.clojure.tools.reader$read.invoke(reader.clj:733)
	at deps.toolsanalyzerjvm.v0v6v6.clojure.tools.analyzer.jvm$analyze_ns$fn__23897.invoke(jvm.clj:545)
	at deps.toolsanalyzerjvm.v0v6v6.clojure.tools.analyzer.jvm$analyze_ns.invoke(jvm.clj:539)
	at deps.toolsanalyzerjvm.v0v6v6.clojure.tools.analyzer.jvm$analyze_ns.invoke(jvm.clj:531)
	at deps.toolsanalyzerjvm.v0v6v6.clojure.tools.analyzer.jvm$analyze_ns.invoke(jvm.clj:530)
	at refactor_nrepl.analyzer$build_ast.invoke(analyzer.clj:59)
	at refactor_nrepl.analyzer$cachable_ast.invoke(analyzer.clj:66)
	at refactor_nrepl.analyzer$ns_ast.invoke(form-init6718292385610975244.clj:5)
	at refactor_nrepl.find_symbol$find_symbol_in_file.invoke(find_symbol.clj:84)
...
```