### PR TITLE
Rewrite clean-ns

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,8 @@
   :plugins [[thomasa/mranderson "0.4.0"]]
   :filespecs [{:type :bytes :path "refactor-nrepl/refactor-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
   :profiles {:provided {:dependencies [[cider/cider-nrepl "0.9.0"]]}
-             :test {:dependencies [[print-foo "1.0.1"]]}
+             :test {:dependencies [[print-foo "1.0.1"]]
+                    :src-paths ["test/resources"]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}

--- a/src/refactor_nrepl/ns/helpers.clj
+++ b/src/refactor_nrepl/ns/helpers.clj
@@ -41,16 +41,30 @@ type is either :require, :use or :import"
 
 (defn suffix
   "java.util.Date -> Date
+  java.text.Normalizer$Form/NFD => Normalizer
+
   clojure.core/str -> str"
   [fully-qualified-name]
-  (cond
-    (= "/" (str fully-qualified-name))
-    fully-qualified-name
+  (let [fully-qualified-name (str fully-qualified-name)]
+    (cond
+      (= "/" fully-qualified-name)
+      fully-qualified-name
 
-    (re-find #"/" (str fully-qualified-name))
-    (-> fully-qualified-name str (.split "/") last)
+      (re-find #"\$" fully-qualified-name)
+      (-> fully-qualified-name (.split "\\$") first suffix)
 
-    :else (-> fully-qualified-name str (.split "\\.") last)))
+      (re-find #"/" (str fully-qualified-name))
+      (-> fully-qualified-name str (.split "/") last)
+
+      :else (-> fully-qualified-name str (.split "\\.") last))))
+
+(defn ctor-call->str
+  "Date. -> \"Date\""
+  [sym]
+  (let [s (str sym)]
+    (if (.endsWith s ".")
+      (.substring s 0 (dec (.length s)))
+      s)))
 
 (defn read-ns-form
   [path]

--- a/src/refactor_nrepl/test.clj
+++ b/src/refactor_nrepl/test.clj
@@ -1,0 +1,6 @@
+(ns refactor-nrepl.test
+  (:require
+   [clojure.string]))
+
+(defn tt [foo bar baz]
+  (println foo bar baz))

--- a/test/resources/ns2.clj
+++ b/test/resources/ns2.clj
@@ -12,7 +12,9 @@
         [clojure.string :rename {replace foo
                                  reverse bar}]
         [clojure.edn :rename {read-string rs
-                              read rd}]))
+                              read rd}])
+  (:import java.text.Normalizer))
+
 (defn use-everything []
   (get-pretty-writer)
   (fresh-line)
@@ -20,4 +22,5 @@
   (compose-fixtures)
   (escape)
   (read-instant-date)
-  (rs))
+  (rs)
+  java.text.Normalizer$Form/NFD)

--- a/test/resources/ns_referencing_macro.clj
+++ b/test/resources/ns_referencing_macro.clj
@@ -1,0 +1,4 @@
+(ns resources.ns-referencing-macro
+  (:require [resources.ns1 :refer [black-hole]]))
+
+(black-hole 'foo 'bar)


### PR DESCRIPTION
The previous implementation relied on the AST to to find some symbols
and a manual walk to find the rest.  Due to the effect of macros we're
already walking so much of the file that we might as well abandon the
AST and walk everything. The new implementation thus walks every form
in the body and collects symbols to use when pruning libspecs and
imports.

The benefit of this approach are as follows

- We're for sure not going to remove a libspec or a referred symbol
  which is needed.
- Since we don't rely on an AST the op will work on files that are in a
  'bad state'.
- This approach should be a lot easier to adapt to .cljs and .cljc files.

The disadvantage of this approach is that we're going to leave some
symbols and libspecs around in the ns form when they are unused.  This
should be limited to symbols found in the :refer clause, and the
community seems to be moving away from referring symbols in favor of
aliasing.

A future commit will take locals into account to limit the amount of
false positives we get when we're looking for a symbol.  This will
improve the accuracy if this op, but I don't think it'll ever get
perfect.

This fixes clojure-emacs/clj-refactor.el#186