### PR TITLE
Add cljs to clean-ns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ pom.xml.asc
 install.cmd
 /install.sh
 /deploy.sh
+/.cljs_nashorn_repl/
+/nashorn_code_cache/

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,10 @@
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :dev {:plugins [[jonase/eastwood "0.2.0"]]
                    :dependencies [[org.clojure/clojure "1.7.0"]
+                                  [org.clojure/clojurescript "1.7.48"]
+                                  [com.cemerick/piggieback "0.2.1"]
                                   [commons-io/commons-io "2.4"]]
+                   :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
                    :java-source-paths ["test/java"]
                    :resource-paths ["test/resources"
                                     "test/resources/testproject/src"]

--- a/src/refactor_nrepl/config.clj
+++ b/src/refactor_nrepl/config.clj
@@ -11,6 +11,17 @@
     :debug false
     }))
 
+;; TODO Get rid of the other stuff and start passing down config
+;; settings on each call instead of keeping state.
+;; NOTE: Update the readme whenever this map is changed
+(def ^:dynamic *config*
+  {:prefix-rewriting true ; Should clean-ns favor prefix forms in the ns macro?
+   ;; Verbose setting for debugging.  The biggest effect this has is
+   ;; to not catch any exceptions to provide meaningful error
+   ;; messages for the client.
+   :debug false
+   })
+
 (defn get-opt
   "Get the opt at key"
   [key]
@@ -44,3 +55,10 @@
 
 (defn configure [{:keys [opts]}]
   (-> opts edn/read-string check-opts set-opts!))
+
+(defmacro with-config
+  "Merge the override map with the default config and execute body."
+  [overrides & body]
+  `(binding [refactor-nrepl.config/*config*
+             (merge refactor-nrepl.config/*config* ~overrides)]
+     ~@body))

--- a/src/refactor_nrepl/ns/clean_ns.clj
+++ b/src/refactor_nrepl/ns/clean_ns.clj
@@ -10,11 +10,11 @@
   * Remove any duplication in the :require and :import form.
   * Remove any unused required namespaces or imported classes.
   * Returns nil when nothing is changed, so the client knows not to do anything."
-  (:require [refactor-nrepl.ns
+  (:require [refactor-nrepl.config :as config]
+            [refactor-nrepl.ns
              [dependencies :refer [extract-dependencies]]
              [helpers :refer [get-ns-component read-ns-form]]
-             [rebuild :refer [rebuild-ns-form]]]
-            [refactor-nrepl.util :refer [throw-unless-clj-file]]))
+             [rebuild :refer [rebuild-ns-form]]]))
 
 (defn- assert-no-exclude-clause
   [use-form]
@@ -29,13 +29,26 @@
   (assert-no-exclude-clause (get-ns-component ns-form :use))
   ns-form)
 
-(defn clean-ns [path]
+(defn- prefix-rewriting?
+  "Cljs doesn't support prefix rewriting.
+
+  If the user passes down an explicit option we use that, otherwise
+  rely on the default."
+  [path prefix-rewriting]
+  (if (.endsWith path "cljs")
+    false
+    (cond
+      (= prefix-rewriting "true") true
+      (= prefix-rewriting "false") false
+      :else (config/get-opt :prefix-rewriting))))
+
+(defn clean-ns [{:keys [path prefix-rewriting]}]
   {:pre [(and (seq path) (string? path))]}
-  (throw-unless-clj-file path)
-  (let [ns-form (read-ns-form path)
-        new-ns-form (->> ns-form
-                         validate
-                         (extract-dependencies path)
-                         (rebuild-ns-form ns-form))]
-    (when-not (= ns-form new-ns-form)
-      new-ns-form)))
+  (config/with-config {:prefix-rewriting (prefix-rewriting? path prefix-rewriting)}
+    (let [ns-form (read-ns-form path)
+          new-ns-form (-> ns-form
+                          validate
+                          (extract-dependencies path)
+                          (rebuild-ns-form ns-form))]
+      (when-not (= ns-form new-ns-form)
+        new-ns-form))))

--- a/src/refactor_nrepl/ns/dependencies.clj
+++ b/src/refactor_nrepl/ns/dependencies.clj
@@ -1,22 +1,26 @@
 (ns refactor-nrepl.ns.dependencies
-  (:require [clojure.walk :as walk]
+  (:require [cider.nrepl.middleware.info :as info]
+            [clojure.walk :as walk]
             [refactor-nrepl.ns
              [helpers :refer [ctor-call->str file-content-sans-ns prefix suffix]]
              [ns-parser :refer [get-imports get-libspecs]]]
-            [cider.nrepl.middleware.info :as info])
+            [refactor-nrepl.util :as util])
   (:import [java.io PushbackReader StringReader]))
 
 (defn- lookup-symbol-ns
-  [current-ns symbol-in-file]
-  (when-let [ns (:ns (info/info {:ns current-ns :symbol symbol-in-file}))]
-    (ns-name ns)))
+  ([ns symbol]
+   (lookup-symbol-ns ns symbol {}))
+  ([current-ns symbol-in-file session]
+   (when-let [ns (:ns (info/info {:ns current-ns :symbol symbol-in-file
+                                  :session session}))]
+     (ns-name ns))))
 
 (defn- libspec-in-use-with-refer-all?
   [{:keys [ns]} current-ns symbol-in-file]
   (= (lookup-symbol-ns current-ns symbol-in-file) ns))
 
 (defn- libspec-in-use-without-refer-all?
-  [{:keys [as ns refer] :as libspec}  current-ns symbol-in-file]
+  [{:keys [as ns refer refer-macros require-macros] :as libspec} symbol-in-file]
   (or
    ;; Used through refer clause
    (and (not= refer :all)
@@ -25,10 +29,9 @@
           ;; This happens as a side-effect of using the symbol in a
           ;; backquoted form when writing macros
           (set (map (fn [symbol-from-refer]
-                      (str (lookup-symbol-ns current-ns symbol-from-refer) "/"
-                           symbol-from-refer))
-                    refer))
-          (map str refer)) symbol-in-file))
+                      (str ns "/" symbol-from-refer))
+                    (concat refer require-macros refer-macros)))
+          (map str (concat refer require-macros refer-macros))) symbol-in-file))
    ;; Used as a fully qualified symbol
    (.startsWith symbol-in-file (str ns "/"))
    ;; Aliased symbol in use
@@ -39,40 +42,35 @@
   (when (if (= refer :all)
           (some (partial libspec-in-use-with-refer-all? libspec current-ns)
                 symbols-in-file)
-          (some (partial libspec-in-use-without-refer-all? libspec current-ns)
+          (some (partial libspec-in-use-without-refer-all? libspec)
                 symbols-in-file))
     libspec))
 
 (defn- referred-symbol-in-use?
-  [current-ns used-syms sym]
+  [symbol-ns used-syms sym]
   (some (fn [sym-from-file]
-          ((into #{(str sym)} [(str (lookup-symbol-ns current-ns sym) "/" sym)])
+          ((into #{(str sym)} [(str symbol-ns "/" sym)])
            sym-from-file))
         used-syms))
 
-(defn- remove-unused-referred-symbols
-  [refer-clause current-ns used-syms]
-  (if (= refer-clause :all)
-    refer-clause
-    (filter (partial referred-symbol-in-use? current-ns used-syms) refer-clause)))
-
-(defn- prune-refer
-  [libspec used-syms current-ns]
-  (update-in libspec [:refer]
-             remove-unused-referred-symbols current-ns used-syms))
-
-(defn remove-empty-refer
-  [{:keys [refer] :as libspec}]
-  (if (and (not= refer :all) (empty? refer))
-    (dissoc libspec :refer)
-    libspec))
+(defn- prune-key [libspec key used-syms]
+  (let [val (key libspec)]
+    (if (and val (not (keyword val)))
+      (assoc libspec key
+             (filter (partial referred-symbol-in-use? (:ns libspec) used-syms)
+                     (key libspec)))
+      libspec)))
 
 (defn- remove-unused-syms-and-specs
   [used-syms current-ns libspec]
   (some-> libspec
           (libspec-in-use? used-syms current-ns)
-          (prune-refer used-syms current-ns)
-          remove-empty-refer))
+          (prune-key :refer used-syms)
+          (prune-key :refer-macros used-syms)
+          (prune-key :require-macros used-syms)
+          (util/dissoc-when (fn empty-and-not-kw [k]
+                              (and (not (keyword k)) (empty? k)))
+                            :refer :refer-macros :require-macros)))
 
 (defn- static-method-or-field-access->Classname
   [symbol-in-file]
@@ -104,31 +102,39 @@
                 (= (:refer libspec) :all))
     (:refer libspec)))
 
-(defn- fix-ns-of-backquoted-forms
-  [current-ns sym]
-  ;; When the reader reads backquoted forms the symbol
-  ;; is fully qualified using the value of *ns* at read
-  ;; time
-  (if (.contains sym (str (ns-name *ns*)))
-    (str (lookup-symbol-ns current-ns (suffix sym)) "/" (suffix sym))
+(defn- find-symbol-ns [libspecs sym]
+  (some->> libspecs
+           (filter (fn [{:keys [refer refer-macros] :as libspec}]
+                     (or (some (partial = (symbol sym)) refer)
+                         (some (partial = (symbol sym)) refer-macros))))
+           first
+           :ns))
+
+(defn- fix-ns-of-backquoted-symbols [libspecs sym]
+  (if (= (prefix sym) (str (ns-name *ns*)))
+    (if-let [prefix (find-symbol-ns libspecs (suffix sym))]
+      (str prefix "/" (suffix sym))
+      sym)
     sym))
 
 (defn- get-symbols-used-in-file
-  [file-content current-ns]
-  (let [rdr (PushbackReader. (StringReader. (file-content-sans-ns file-content)))
-        syms (atom [])
-        collect-symbol (fn [form]
-                         (when (symbol? form)
-                           (swap! syms conj (ctor-call->str form)))
-                         form)]
-    (loop [form (read rdr nil :eof)]
-      (when (not= form :eof)
-        (walk/prewalk collect-symbol form)
-        (recur (read rdr nil :eof))))
-    (set (map (partial fix-ns-of-backquoted-forms current-ns) @syms))))
+  [file-content current-ns libspecs]
+  (binding [*ns* (or (find-ns (symbol current-ns)) *ns*)]
+    (let [rdr (PushbackReader. (StringReader. (file-content-sans-ns file-content)))
+          syms (atom #{})
+          collect-symbol (fn [form]
+                           (when (symbol? form)
+                             (swap! syms conj (ctor-call->str form)))
+                           form)]
+      (loop [form (read rdr nil :eof)]
+        (when (not= form :eof)
+          (walk/prewalk collect-symbol form)
+          (recur (read rdr nil :eof))))
+      (set (map (partial fix-ns-of-backquoted-symbols libspecs) @syms)))))
 
 (defn- remove-unused-requires [symbols-in-file current-ns libspecs]
-  (map (partial remove-unused-syms-and-specs symbols-in-file current-ns) libspecs))
+  (map (partial remove-unused-syms-and-specs symbols-in-file current-ns)
+       libspecs))
 
 (defn- get-classes-used-in-typehints [file-content]
   (let [rdr (PushbackReader. (StringReader. (file-content-sans-ns file-content)))
@@ -155,11 +161,12 @@
       get-imports
       (remove-unused-imports symbols-in-file)))
 
-(defn extract-dependencies [path ns-form]
+(defn extract-dependencies [ns-form path]
   (let [libspecs (get-libspecs ns-form)
         file-content (slurp path)
         current-ns (second ns-form)
-        symbols-in-file (into (get-symbols-used-in-file file-content current-ns)
+        symbols-in-file (into (get-symbols-used-in-file file-content current-ns
+                                                        libspecs)
                               (get-classes-used-in-typehints file-content))]
     {:require (prune-libspecs libspecs symbols-in-file current-ns)
      :import (prune-imports ns-form symbols-in-file)}))

--- a/src/refactor_nrepl/ns/helpers.clj
+++ b/src/refactor_nrepl/ns/helpers.clj
@@ -25,7 +25,7 @@
 (defn get-ns-component
   "Extracts a sub-component from the ns declaration.
 
-type is either :require, :use or :import"
+type is a toplevel keyword in the ns form e.g. :require or :use."
   [ns type]
   (some->> (index-of-component ns type) (nth ns)))
 

--- a/src/refactor_nrepl/ns/ns_parser.clj
+++ b/src/refactor_nrepl/ns/ns_parser.clj
@@ -2,12 +2,17 @@
   "Extracts a list of imports or libspecs from an ns form.  A libspec
   looks like this:
 
-  {:ns ns-name
-   :as alias
+  {:ns my-ns
+   :as my-alias
    :refer [referred symbols here] ;; or :all
    :rename {:rename :spec}
-   :only [only these symbols]}"
-  (:require [refactor-nrepl.ns.helpers :refer [get-ns-component prefix-form?]]))
+   :only [only these symbols]
+
+   ;; rest are cljs specific
+   :refer-macros [referred macros here]
+   :require-macros true}"
+  (:require [refactor-nrepl.ns.helpers :refer [get-ns-component prefix-form?]]
+            [refactor-nrepl.util :as util]))
 
 (defn- libspec-vector->map
   [libspec]
@@ -33,21 +38,47 @@
                                      [libspec]))]
     (mapcat normalize-libspec-vector libspecs)))
 
-(defn- use-to-refer-all [use-specs]
-  (map (fn [use-spec] (if (vector? use-spec)
-                        (if (prefix-form? use-spec)
-                          [(first use-spec) (map #(conj % :refer :all))]
-                          (conj use-spec :refer :all))
-                        [use-spec :refer :all]))
-       use-specs))
+(defn- use-to-refer-all [use-spec]
+  (if (vector? use-spec)
+    (if (prefix-form? use-spec)
+      [(first use-spec) (map #(conj % :refer :all))]
+      (conj use-spec :refer :all))
+    [use-spec :refer :all]))
+
+(defmacro with-libspecs-from
+  "Bind the symbol libspecs to the libspecs extracted from the key in
+  ns-form and execute body."
+  [ns-form key & body]
+  `(let [~'libspecs (rest (get-ns-component ~ns-form ~key))]
+     ~@body))
+
+(defn- extract-required-macros [libspec-vector]
+  {:ns (first libspec-vector)
+   :require-macros (drop-while #(not= :refer %) libspec-vector)})
+
+(defn- extract-libspecs [ns-form]
+  (mapcat identity
+          [(with-libspecs-from ns-form :require
+             (->> libspecs
+                  expand-prefix-specs
+                  (map libspec-vector->map)))
+           (with-libspecs-from ns-form :require-macros
+             (->> libspecs
+                  (map libspec-vector->map)
+                  (map (partial util/rename-key :refer :require-macros))))
+           (with-libspecs-from ns-form :use
+             (->> libspecs
+                  expand-prefix-specs
+                  (map use-to-refer-all)
+                  (map libspec-vector->map)))
+           (with-libspecs-from ns-form :use-macros
+             (->> libspecs
+                  (map libspec-vector->map)
+                  (map (partial util/rename-key :only :require-macros))))]))
 
 (defn get-libspecs [ns-form]
-  (->> (get-ns-component ns-form :use)
-       rest ; drop :use keyword
-       use-to-refer-all
-       (into (rest (get-ns-component ns-form :require)))
-       expand-prefix-specs
-       (map libspec-vector->map)
+  (->> ns-form
+       extract-libspecs
        distinct))
 
 (defn get-imports [ns-form]

--- a/src/refactor_nrepl/rename_file_or_dir.clj
+++ b/src/refactor_nrepl/rename_file_or_dir.clj
@@ -2,13 +2,15 @@
   (:require [clojure.string :as str]
             [clojure.tools.namespace.file :as file]
             [me.raynes.fs :as fs]
+            [refactor-nrepl
+             [config :as config]
+             [util :as util]]
             [refactor-nrepl.ns
              [helpers :refer [file-content-sans-ns read-ns-form]]
              [ns-parser :as ns-parser]
              [pprint :refer [pprint-ns]]
              [rebuild :refer [rebuild-ns-form]]
-             [tracker :as tracker]]
-            [refactor-nrepl.util :as util])
+             [tracker :as tracker]])
   (:import java.io.File
            java.nio.file.Files
            java.util.regex.Pattern))
@@ -73,7 +75,7 @@
         classes (ns-parser/get-imports ns-form)
         deps {:require (update-libspecs libspecs old-ns new-ns)
               :import (update-class-references classes old-ns new-ns)}]
-    (pprint-ns (rebuild-ns-form ns-form deps) (.getAbsolutePath file))))
+    (pprint-ns (rebuild-ns-form deps ns-form) (.getAbsolutePath file))))
 
 (defn- update-file-content-sans-ns
   "Any fully qualified references to old-ns has to be replaced with new-ns."

--- a/src/refactor_nrepl/util.clj
+++ b/src/refactor_nrepl/util.clj
@@ -206,3 +206,17 @@
   "Return a new map where (pred [k v]) is true for every key-value pair."
   [pred m]
   (into {} (filter pred m)))
+
+(defn rename-key
+  "Rename the key in m to new-name."
+  [key new-name m]
+  (-> m
+      (assoc new-name (key m))
+      (dissoc key)))
+
+(defn dissoc-when
+  "Remove the enumerated keys from m on which pred is truthy."
+  [m pred & keys]
+  (if (seq keys)
+    (reduce (fn [m k] (if (pred (get m k)) (dissoc m k) m)) m keys)
+    m))

--- a/test/refactor_nrepl/integration_tests.clj
+++ b/test/refactor_nrepl/integration_tests.clj
@@ -31,7 +31,6 @@
        (finally
          (.delete ~'tmp-dir)))))
 
-
 (defn start-up-repl-server []
   (let [server
         (nrserver/start-server

--- a/test/refactor_nrepl/ns/ns_parser_test.clj
+++ b/test/refactor_nrepl/ns/ns_parser_test.clj
@@ -33,3 +33,10 @@
                          (:require [refactor-nrepl.ns.ns-parser :refer :all]
                                    [clojure.test :refer :all])
                          (:import [java.util Date Calendar]))))))
+
+(deftest parses-require-macros
+  (is (= '({:ns cljs.test :refer-macros [deftest is]}
+           {:ns cljs.test :require-macros [testing run-tests]})
+         (get-libspecs '(ns test
+                          (:require [cljs.test :refer-macros [deftest is]])
+                          (:require-macros [cljs.test :refer [testing run-tests]]))))))

--- a/test/resources/cljsns.cljs
+++ b/test/resources/cljsns.cljs
@@ -1,15 +1,26 @@
 (ns resources.cljsns
-  (:require [chord.client :refer [ws-ch]]
-            [cljs.core.async :refer [<!]]
-            [undead.components :refer [render-game]]
-            [clojure.pprint :as pprint :require-macros true]
-            [clojure.set]
-            [clojure.string :as str])
-  (:require-macros [cljs.core.async.macros :refer [go]]))
+  (:require [cljs.test :refer-macros [is deftest]]
+            [cljs.test :refer-macros [is]]
+            [clojure.string :refer [split-lines join]]
+            [cljs.pprint :as pprint]
+            [clojure.set :as set])
+  (:require-macros [cljs.test :refer [testing]])
+  (:use-macros [cljs.test :only [run-tests]])
+  (:import goog.string))
 
-(defn use-some-of-it
-  (go (<! (ws-ch)))
-  (render-game 'game))
+(defn use-some-of-it []
+  (pprint/pprint {:foo :bar})
+  (set/intersection #{1 2} #{1})
+  (split-lines "ok"))
 
-(defmacro a-macro []
-  (pprint/pprint "string"))
+(deftest tt
+  (testing "whatever"
+      (is (= 1 1))))
+
+(defn foo []
+  `(join "foo bar"))
+
+(fn []
+  (run-tests))
+
+(string/regExpEscape "ok")

--- a/test/resources/cljsns_cleaned.cljs
+++ b/test/resources/cljsns_cleaned.cljs
@@ -1,6 +1,7 @@
 (ns resources.cljsns
-  (:require [chord.client :refer [ws-ch]]
-            [cljs.core.async :refer [<!]]
-            [clojure.pprint :as pprint :require-macros true]
-            [undead.components :refer [render-game]])
-  (:require-macros [cljs.core.async.macros :refer [go]]))
+  (:require [cljs.pprint :as pprint]
+            [cljs.test :refer-macros [deftest is]]
+            [clojure.set :as set]
+            [clojure.string :refer [join split-lines]])
+  (:require-macros [cljs.test :refer [run-tests testing]])
+  (:import goog.string))


### PR DESCRIPTION
There's now support for:

* pruning of libspecs and imports
* sorting of libspecs and imports
* removal of :use
* :refer-macros are pruned and sorted
* :require-macros are pruned and sorted
* :use-macros are re-written to :require-macros

For now I'm not going to update the readme or  the changelog because this
is likely to still be somewhat rough around the edges.