### PR TITLE
Add namespace-aliases op

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,12 @@ The goal of the op is to provide intelligent suggestions when the user wants to 
 
 The op requires `symbol` which represents a name to look up on the classpath.
 
-The return value `candidates` is an alist of `((candidate1 . type1) (candidate2 . type2) ...)` where type is in `#{:type :class :ns}` so we can branch on the 3 various way to import.  `:type` means the symbol resolved to a var created by `defrecord` or `deftype`, `:class` also includes interfaces.
+The return value `candidates` is an alist of `((candidate1 . type1)
+(candidate2 . type2) ...)` where type is in `#{:type :class :ns
+:macro}` so we can branch on the various ways to make the symbol
+available.  `:type` means the symbol resolved to a var created by
+`defrecord` or `deftype`, `:class` also includes interfaces.  `:macro`
+is only used if the op is called in a cljs context.
 
 ### hotload-dependency
 
@@ -271,6 +276,20 @@ This op can cause serious havoc if it crashes midway through the
 refactoring.  I recommend not running it without first creating a
 restore point in your version control system.
 
+### namespace-aliases
+
+Returns `namespace-aliases` which is a list of all the namespace aliases that are in use in the
+project. The reply looks like this:
+
+```clj
+{:clj
+ {t (clojure.test),
+  set (clojure.set),
+  tracker (refactor-nrepl.ns.tracker clojure.tools.namespace.track)},
+ :cljs {set (clojure.set), pprint (cljs.pprint)}}
+```
+The list of suggestions is sorted by frequency in decreasing order, so the first element is always the best suggestion.
+
 ### Errors
 
 The middleware returns errors under one of two keys: `:error` or
@@ -318,7 +337,8 @@ build.sh cleans, runs source-deps with the right parameters, runs the tests and 
 ## Changelog
 
 ### Unreleased
-* Make `find-symbol` able to handle macros
+* Add `namespace-aliases` which provides a mapping of the namespace aliases that are in use in the project.
+* Make `find-symbol` able to handle macros.
 
 ### 1.1.0
 

--- a/src/refactor_nrepl/find/find_macros.clj
+++ b/src/refactor_nrepl/find/find_macros.clj
@@ -43,7 +43,7 @@
   [path]
   (util/with-additional-ex-data [:file path]
     (with-open [file-rdr (FileReader. path)]
-      (binding [*ns* (or (ns-helpers/path->namespace path :no-error) *ns*)]
+      (binding [*ns* (or (ns-helpers/path->namespace :no-error path) *ns*)]
         (let [rdr (LineNumberingPushbackReader. file-rdr)]
           (loop [macros [], form (reader/read rdr nil :eof)]
             (cond
@@ -185,7 +185,7 @@
          ;; Fail gracefully instead of blowing up with reader errors
          ;; when project contains cljc files until we had proper
          ;; support
-         (empty? (util/find-cljc-files-in-project))
+         (empty? (util/filter-project-files util/cljc-file?))
          (fully-qualified-name? fully-qualified-name))
     (let [all-defs (find-macro-definitions-in-project)
           macro-def (first (filter #(= (:name %) fully-qualified-name) all-defs))

--- a/src/refactor_nrepl/middleware.clj
+++ b/src/refactor_nrepl/middleware.clj
@@ -19,6 +19,7 @@
              [find-unbound :refer [find-unbound-vars]]]
             [refactor-nrepl.ns
              [clean-ns :refer [clean-ns]]
+             [namespace-aliases :refer [namespace-aliases]]
              [pprint :refer [pprint-ns]]
              [resolve-missing :refer [resolve-missing]]]))
 
@@ -101,6 +102,11 @@
   (reply transport msg :touched (rename-file-or-dir old-path new-path)
          :status :done))
 
+(defn- namespace-aliases-reply [{:keys [transport] :as msg}]
+  (reply transport msg
+         :namespace-aliases (serialize-response msg (namespace-aliases))
+         :status :done))
+
 (def refactor-nrepl-ops
   {
    "artifact-list" artifact-list-reply
@@ -112,6 +118,7 @@
    "find-symbol" find-symbol-reply
    "find-unbound" find-unbound-reply
    "hotload-dependency" hotload-dependency-reply
+   "namespace-aliases" namespace-aliases-reply
    "rename-file-or-dir" rename-file-or-dir-reply
    "resolve-missing" resolve-missing-reply
    "stubs-for-interface" stubs-for-interface-reply

--- a/src/refactor_nrepl/ns/helpers.clj
+++ b/src/refactor_nrepl/ns/helpers.clj
@@ -71,13 +71,13 @@ type is a toplevel keyword in the ns form e.g. :require or :use."
   "Read the ns form found at PATH.
 
   If no ns form can be read, throw an error unless NO-ERROR is passed."
-  ([path] (read-ns-form path nil))
-  ([path no-error]
+  ([path] (read-ns-form nil path))
+  ([no-error path]
    (with-open [file-reader (FileReader. path)]
      (if-let [ns-form (read-ns-decl (PushbackReader. file-reader))]
        ns-form
        (when-not no-error
-         (throw (IllegalArgumentException. "Malformed ns form!")))))))
+         (throw (IllegalArgumentException. (str "Malformed ns form in " path))))))))
 
 (defn path->namespace
   "Read the ns form found at PATH and return the namespace object for
@@ -85,8 +85,8 @@ type is a toplevel keyword in the ns form e.g. :require or :use."
 
   if NO-ERROR is passed just return nil instead of an exception if we
   can't successfully read an ns form."
-  ([path] (path->namespace path nil))
-  ([path no-error] (some-> path (read-ns-form no-error) second find-ns)))
+  ([path] (path->namespace nil path))
+  ([no-error path] (some->> path (read-ns-form no-error) second find-ns)))
 
 (defn file-content-sans-ns [file-content]
   ;; NOTE: It's tempting to trim this result but

--- a/src/refactor_nrepl/ns/namespace_aliases.clj
+++ b/src/refactor_nrepl/ns/namespace_aliases.clj
@@ -1,0 +1,36 @@
+(ns refactor-nrepl.ns.namespace-aliases
+  (:require [refactor-nrepl.ns
+             [helpers :as ns-helpers]
+             [ns-parser :as ns-parser]]
+            [refactor-nrepl.util :as util]))
+
+(defn- aliases [libspecs]
+  (->> libspecs
+       (map #(vector (:as %) (:ns %)))
+       (remove #(nil? (first %)))
+       distinct))
+
+(defn- aliases-by-frequencies [libspecs]
+  (->> libspecs
+       (mapcat aliases) ; => [[str clojure.string] ...]
+       (sort-by second)
+       (group-by first) ; => {str [[str clojure.string] [str clojure.string]] ...}
+       (map (comp seq frequencies second)) ; => (([[set clojure.set] 4] [set set] 1) ...)
+       (map (partial sort-by second >)) ; by decreasing frequency
+       (map (partial map first)) ; drop frequencies
+       (map (fn [aliases] (list (ffirst aliases) (map second aliases))))
+       (mapcat identity)
+       (apply hash-map)))
+
+(defn namespace-aliases
+  "Return a map of file type to a map of aliases to namespaces
+
+  {:clj {util com.acme.util str clojure.string
+   :cljs {gstr goog.str}}}"
+  []
+  {:clj (->> (util/filter-project-files util/clj-file?)
+             (map ns-parser/get-libspecs-from-file)
+             aliases-by-frequencies)
+   :cljs (->> (util/filter-project-files util/cljs-file?)
+              (map ns-parser/get-libspecs-from-file)
+              aliases-by-frequencies)})

--- a/src/refactor_nrepl/ns/ns_parser.clj
+++ b/src/refactor_nrepl/ns/ns_parser.clj
@@ -12,7 +12,9 @@
    :refer-macros [referred macros here]
    :require-macros true}"
   (:require [refactor-nrepl.ns.helpers :refer [get-ns-component prefix-form?]]
-            [refactor-nrepl.util :as util]))
+            [refactor-nrepl.util :as util]
+            [refactor-nrepl.ns.helpers :refer [read-ns-form]])
+  (:import java.io.File))
 
 (defn- libspec-vector->map
   [libspec]
@@ -77,9 +79,9 @@
                   (map (partial util/rename-key :only :require-macros))))]))
 
 (defn get-libspecs [ns-form]
-  (->> ns-form
-       extract-libspecs
-       distinct))
+  (some->> ns-form
+           extract-libspecs
+           distinct))
 
 (defn get-imports [ns-form]
   (let [expand-prefix-specs (fn [import-spec]
@@ -94,3 +96,10 @@
              (map expand-prefix-specs)
              flatten
              distinct)))
+
+(defn get-libspecs-from-file
+  [^File f]
+  (some->> f
+           .getAbsolutePath
+           (read-ns-form :no-error)
+           get-libspecs))

--- a/src/refactor_nrepl/util.clj
+++ b/src/refactor_nrepl/util.clj
@@ -51,8 +51,24 @@
   [^File f]
   (.endsWith (.getPath f) ".cljc"))
 
-(defn find-cljc-files-in-project []
-  (mapcat (partial find-in-dir cljc-file?) (dirs-on-classpath*)))
+(defn cljs-file?
+  [^File f]
+  (.endsWith (.getPath f) ".cljs"))
+
+(defn clj-file?
+  [^File f]
+  (.endsWith (.getPath f) ".clj"))
+
+(defn source-file?
+  "True for clj or cljs files."
+  [^File f]
+  (or (.endsWith (.getPath f) ".clj")
+      (.endsWith (.getPath f) ".cljs")))
+
+(defn filter-project-files
+  "Return the files in the project satisfying (pred ^File file)."
+  [pred]
+  (mapcat (partial find-in-dir pred) (dirs-on-classpath*)))
 
 (defn node-at-loc? [loc-line loc-column node]
   (let [{:keys [line end-line column end-column]} (:env node)]

--- a/test/refactor_nrepl/ns/namespace_aliases_test.clj
+++ b/test/refactor_nrepl/ns/namespace_aliases_test.clj
@@ -1,0 +1,25 @@
+(ns refactor-nrepl.ns.namespace-aliases-test
+  (:require [clojure.test :as t]
+            [refactor-nrepl.ns
+             [helpers :as util]
+             [namespace-aliases :as sut]]
+            [refactor-nrepl.util :as rutil]))
+
+(t/deftest finds-the-aliases-in-this-ns
+  (let [aliases (:clj (sut/namespace-aliases))]
+    (t/is (some #(and (= (first %) 'sut)
+                      (= (first (second %)) 'refactor-nrepl.ns.namespace-aliases))
+                aliases))))
+
+(t/deftest finds-the-cljs-alises-in-cljsns
+  (let [aliases (:cljs (sut/namespace-aliases))]
+    (t/is (some #(and (= (first %) 'pprint)
+                      (= (first (second %)) 'cljs.pprint))
+                aliases))))
+
+(t/deftest sorts-by-frequencies
+  (let [aliases (:clj (sut/namespace-aliases))
+        _ (util/ns-form-from-string "(ns foo)")
+        utils (get (rutil/filter-map #(= (first %) 'util) aliases) 'util)]
+    (t/is (= (first utils) 'refactor-nrepl.util))
+    (t/is (some #(= % 'refactor-nrepl.ns.helpers) utils))))


### PR DESCRIPTION
This new op returns information about all the namespace aliases that are
in use in the project.

In cljr-refactor we use this to automatically require the right thing
when the user types something like `util/great-util`.

https://github.com/clojure-emacs/clj-refactor.el/pull/219