### PR TITLE
Rework how config works

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ You also need to pass in the path to the file you want to refactor. Pass in a pa
 
 ## Available features
 
-### Configure
+### Configuration
 
-The `configure` op takes a single argument `opts` which is an options map to use for the current session.  At present this settings map looks like this:
+Configuration settings are passed along with each msg, currently the recognized options are as follows:
 
 ```clj
 {
@@ -59,7 +59,7 @@ The `configure` op takes a single argument `opts` which is an options map to use
 }
 ```
 
-The op returns a `status` of `done` on success and an `error` with a message intended for the user in the event of failure.
+Any configuration settings passed along with the message will replace the defaults above.
 
 ### Find (debug) function invocations
 
@@ -180,7 +180,7 @@ In the event of an error `clean-ns` will return `error` which is an error messag
 
 **Warning**: The `clean -ns` op dependes on `tools.analyzer` to determine which vars in a file are actually being used.  This means the code is evaluated and any top-level occurrences of `(launch-missiles)` should be avoided.
 
-This op can be [configured](#configure).
+This op can be [configured](#configuration).
 
 ### resolve-missing
 
@@ -337,6 +337,7 @@ build.sh cleans, runs source-deps with the right parameters, runs the tests and 
 ## Changelog
 
 ### Unreleased
+* Drop the `configure` op, and receive settings in each message.
 * Add `namespace-aliases` which provides a mapping of the namespace aliases that are in use in the project.
 * Make `find-symbol` able to handle macros.
 

--- a/src/refactor_nrepl/analyzer.clj
+++ b/src/refactor_nrepl/analyzer.clj
@@ -74,7 +74,7 @@
   (let [ast-or-err (cachable-ast file-content)]
     (cond
       (and (instance? Throwable ast-or-err)
-           (config/get-opt :debug))
+           (:debug config/*config*))
       (throw ast-or-err)
 
       (instance? Throwable ast-or-err)

--- a/src/refactor_nrepl/config.clj
+++ b/src/refactor_nrepl/config.clj
@@ -1,18 +1,5 @@
-(ns refactor-nrepl.config
-  (:require [clojure.edn :as edn]))
+(ns refactor-nrepl.config)
 
-;; NOTE: Update the readme whenever this map is changed
-(def ^:private opts
-  (atom
-   {:prefix-rewriting true ; Should clean-ns favor prefix forms in the ns macro?
-    ;; Verbose setting for debugging.  The biggest effect this has is
-    ;; to not catch any exceptions to provide meaningful error
-    ;; messages for the client.
-    :debug false
-    }))
-
-;; TODO Get rid of the other stuff and start passing down config
-;; settings on each call instead of keeping state.
 ;; NOTE: Update the readme whenever this map is changed
 (def ^:dynamic *config*
   {:prefix-rewriting true ; Should clean-ns favor prefix forms in the ns macro?
@@ -22,43 +9,16 @@
    :debug false
    })
 
-(defn get-opt
-  "Get the opt at key"
-  [key]
-  (get @opts key))
-
-(defn contains-opt?
-  "Checks if key is present in the opts map."
-  [key]
-  (contains? @opts key))
-
-(defn- set-opts!
-  "Sets the options for the current session."
-  [m]
-  (doseq [[k v] m]
-    (swap! opts assoc k v)))
-
-(defn- check-opts [opts]
-  (when-not (map? opts)
-    (throw (IllegalArgumentException.
-            (str "Options must be a map, got '" opts "'"))))
-  (doseq [k (keys opts)]
-    (when-not (contains-opt? k)
-      (throw (IllegalArgumentException.
-              (str "Unknown key in config map: " k)))))
-  opts)
-
-(defn set-opt!
-  "Set the option under key k to value v."
-  [k v]
-  (swap! opts assoc k v))
-
-(defn configure [{:keys [opts]}]
-  (-> opts edn/read-string check-opts set-opts!))
+(defn opts-from-msg [msg]
+  (into {}
+        (map (fn [[k v]] (cond
+                           (and (string? v) (= v "true")) [k true]
+                           (string? v) [k false]
+                           :else [k v]))
+             (select-keys msg (keys *config*)))))
 
 (defmacro with-config
   "Merge the override map with the default config and execute body."
   [overrides & body]
-  `(binding [refactor-nrepl.config/*config*
-             (merge refactor-nrepl.config/*config* ~overrides)]
+  `(binding [*config* (merge *config* (opts-from-msg ~overrides))]
      ~@body))

--- a/src/refactor_nrepl/ns/clean_ns.clj
+++ b/src/refactor_nrepl/ns/clean_ns.clj
@@ -29,22 +29,12 @@
   (assert-no-exclude-clause (get-ns-component ns-form :use))
   ns-form)
 
-(defn- prefix-rewriting?
-  "Cljs doesn't support prefix rewriting.
-
-  If the user passes down an explicit option we use that, otherwise
-  rely on the default."
-  [path prefix-rewriting]
-  (if (.endsWith path "cljs")
-    false
-    (cond
-      (= prefix-rewriting "true") true
-      (= prefix-rewriting "false") false
-      :else (config/get-opt :prefix-rewriting))))
-
-(defn clean-ns [{:keys [path prefix-rewriting]}]
+(defn clean-ns [{:keys [path]}]
   {:pre [(and (seq path) (string? path))]}
-  (config/with-config {:prefix-rewriting (prefix-rewriting? path prefix-rewriting)}
+  ;; prefix notation not supported in cljs
+  (config/with-config {:prefix-rewriting (if (.endsWith path "cljs")
+                                           false
+                                           (:prefix-rewriting config/*config*))}
     (let [ns-form (read-ns-form path)
           new-ns-form (-> ns-form
                           validate

--- a/src/refactor_nrepl/ns/rebuild.clj
+++ b/src/refactor_nrepl/ns/rebuild.clj
@@ -1,7 +1,7 @@
 (ns refactor-nrepl.ns.rebuild
   (:require [clojure.string :as str]
             [refactor-nrepl
-             [config :refer [get-opt]]
+             [config :as config]
              [util :as util]]
             [refactor-nrepl.ns.helpers
              :refer
@@ -156,7 +156,7 @@
 
 (defn- create-prefixed-libspec-vectors
   [[libspec & more :as libspecs]]
-  (if-not (:prefix-rewriting refactor-nrepl.config/*config*)
+  (if-not (:prefix-rewriting config/*config*)
     (create-libspec-vectors-with-prefix libspecs)
     (if-not more
       (create-libspec-vectors-with-prefix [libspec])

--- a/test/refactor_nrepl/config_test.clj
+++ b/test/refactor_nrepl/config_test.clj
@@ -1,18 +1,15 @@
 (ns refactor-nrepl.config-test
-  (:require [refactor-nrepl
+  (:require [clojure.set :as set]
+            [clojure.test :refer :all]
+            [refactor-nrepl
              [analyzer :as analyzer]
-             [config :refer :all]]
-            [clojure.test :refer :all]))
-
-(deftest throws-on-bad-config
-  (is (thrown? IllegalArgumentException (configure "invalid")))
-  (is (thrown? IllegalArgumentException (configure {:invalid-key 1}))))
+             [config :as sut]]))
 
 (deftest error-from-ast-is-sent-to-user-with-debug-setting
   (with-redefs [refactor-nrepl.analyzer/cachable-ast (fn [& _] (IllegalThreadStateException. "NO!"))]
     (testing "Throws pretty error with :debug false"
-      (set-opt! :debug false)
-      (is (thrown? IllegalStateException (analyzer/ns-ast "my-file"))))
+      (sut/with-config {:debug false}
+        (is (thrown? IllegalStateException (analyzer/ns-ast "my-file")))))
     (testing "Throws original exception with :debug true"
-      (set-opt! :debug true)
-      (is (thrown? IllegalThreadStateException (analyzer/ns-ast "my-file"))))))
+      (sut/with-config {:debug true}
+        (is (thrown? IllegalThreadStateException (analyzer/ns-ast "my-file")))))))

--- a/test/refactor_nrepl/ns/namespace_aliases_test.clj
+++ b/test/refactor_nrepl/ns/namespace_aliases_test.clj
@@ -7,11 +7,13 @@
 
 (t/deftest finds-the-aliases-in-this-ns
   (let [aliases (:clj (sut/namespace-aliases))]
-    (t/is (some #(and (= (first %) 'sut)
-                      (= (first (second %)) 'refactor-nrepl.ns.namespace-aliases))
+    (t/is (some (fn [alias]
+                  (and (= (first alias) 'sut)
+                       (= (some #(= % 'refactor-nrepl.ns.namespace-aliases)
+                                (second alias)))))
                 aliases))))
 
-(t/deftest finds-the-cljs-alises-in-cljsns
+(t/deftest finds-the-cljs-aliases-in-cljsns
   (let [aliases (:cljs (sut/namespace-aliases))]
     (t/is (some #(and (= (first %) 'pprint)
                       (= (first (second %)) 'cljs.pprint))


### PR DESCRIPTION
We no longer store the config state but the receive the config settings
as part of each message form the clients.

This is easier in so many ways.

- Don't have to store state.
- Don't have to deal with config messages
- Don't have to let the user know that config changes don't take effect
  until they call a function like `cljr-refresh-middleware-config`