### PR TITLE
Make find-macros aware of cljc files, require 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: clojure
 script:
   - lein2 source-deps :prefix-exclusions "[\"classlojure\"]"
-  - lein2 with-profile +1.5,+plugin.mranderson/config test
-  - lein2 with-profile +1.6,+plugin.mranderson/config test
-  - lein2 with-profile +1.7,+plugin.mranderson/config test
+  - lein2 with-profile +plugin.mranderson/config test
 jdk:
   - openjdk7
   - oraclejdk7

--- a/project.clj
+++ b/project.clj
@@ -18,9 +18,6 @@
   :profiles {:provided {:dependencies [[cider/cider-nrepl "0.9.0"]]}
              :test {:dependencies [[print-foo "1.0.1"]]
                     :src-paths ["test/resources"]}
-             :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
-             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :dev {:plugins [[jonase/eastwood "0.2.0"]]
                    :dependencies [[org.clojure/clojure "1.7.0"]
                                   [org.clojure/clojurescript "1.7.48"]

--- a/test/refactor_nrepl/find/find_macros_test.clj
+++ b/test/refactor_nrepl/find/find_macros_test.clj
@@ -36,3 +36,11 @@
 
 (deftest find-fully-qualified-fn
   (is (nil? (find-macro "refactor-nrepl.find.find-macros/find-macro"))))
+
+(deftest finds-macro-defined-in-cljc-file
+  (is (found? #"defmacro cljc-macro"
+              (find-macro "com.example.macro-def-cljc/cljc-macro"))))
+
+(deftest finds-macro-defined-in-cljc-file-and-used-in-clj-file
+  (is (found? #"(com.example.macro-def-cljc/cljc-macro :fully-qualified)"
+              (find-macro "com.example.macro-def-cljc/cljc-macro"))))

--- a/test/resources/testproject/src/com/example/fully_qualified_macro_usage.clj
+++ b/test/resources/testproject/src/com/example/fully_qualified_macro_usage.clj
@@ -1,5 +1,7 @@
 (ns com.example.fully-qualified-macro-usage
-  (:require com.example.macro-def))
+  (:require com.example.macro-def
+            com.example.macro-def-cljc))
 
 (defn fully-qualified-macro-usage []
-  (com.example.macro-def/my-macro :fully-qualified))
+  (com.example.macro-def/my-macro :fully-qualified)
+  (com.example.macro-def-cljc/cljc-macro :fully-qualified))

--- a/test/resources/testproject/src/com/example/macro_def_cljc.cljc
+++ b/test/resources/testproject/src/com/example/macro_def_cljc.cljc
@@ -1,0 +1,4 @@
+(ns com.example.macro-def-cljc)
+
+#?(:clj
+   (defmacro cljc-macro [& body]))


### PR DESCRIPTION
Macros defined in cljc files are now correctly found.  Their usage in
clj files is correctly tracked.

In order to deal with cljc files we're going to require clojure 1.7.