### PR TITLE
Add cljs support to resolve-missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ install.cmd
 /.cljs_nashorn_repl/
 /.cljs_rhino_repl/
 /nashorn_code_cache/
+/.cljs_rhino_repl/
+/.cljs_node_repl/

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ build.sh cleans, runs source-deps with the right parameters, runs the tests and 
 ## Changelog
 
 ### Unreleased
+* Add cljs support to `resolve-missing`.
 * Drop the `configure` op, and receive settings in each message.
 * Add `namespace-aliases` which provides a mapping of the namespace aliases that are in use in the project.
 * Make `find-symbol` able to handle macros.

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,8 @@
                  ^:source-dep [org.clojure/tools.reader "0.10.0-alpha3"]
                  ^:source-dep [org.clojure/java.classpath "0.2.2"]
                  ^:source-dep [me.raynes/fs "1.4.6"]
-                 ^:source-dep [rewrite-clj "0.4.12"]]
+                 ^:source-dep [rewrite-clj "0.4.12"]
+                 ^:source-dep [cljs-tooling "0.1.7"]]
   :plugins [[thomasa/mranderson "0.4.5"]]
   :filespecs [{:type :bytes :path "refactor-nrepl/refactor-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
   :profiles {:provided {:dependencies [[cider/cider-nrepl "0.9.0"]]}

--- a/test/refactor_nrepl/ns/resolve_missing_test.clj
+++ b/test/refactor_nrepl/ns/resolve_missing_test.clj
@@ -1,0 +1,79 @@
+(ns refactor-nrepl.ns.resolve-missing-test
+  (:require [cemerick.piggieback :as piggieback]
+            [clojure.edn :as edn]
+            [clojure.test :as t]
+            [clojure.tools.nrepl :as nrepl]
+            [clojure.tools.nrepl.server :as server]
+            [refactor-nrepl.middleware :as middleware]))
+
+(def ^:dynamic *handler* (server/default-handler #'middleware/wrap-refactor))
+(def ^:dynamic *session* nil)
+
+(defn session-fixture
+  [f]
+  (with-open [server (server/start-server :handler *handler*)
+              transport (nrepl/connect :port (:port server))]
+    (let [client (nrepl/client transport Long/MAX_VALUE)]
+      (binding [*session* (nrepl/client-session client)]
+        (f)))))
+
+(defn message
+  ([msg] (message msg true))
+  ([msg combine-responses?]
+   (let [responses (nrepl/message *session* msg)]
+     (if combine-responses?
+       (nrepl/combine-responses responses)
+       responses))))
+
+(def piggieback-fixture
+  (t/compose-fixtures
+   session-fixture
+   (fn [f]
+     (binding [*handler* (server/default-handler
+                           #'refactor-nrepl.middleware/wrap-refactor
+                           #'piggieback/wrap-cljs-repl)]
+       (message {:op :eval
+                 :code (nrepl/code
+                        (require '[cemerick.piggieback :as piggieback])
+                        (require '[cljs.repl.node :as node])
+                        (piggieback/cljs-repl (node/repl-env)))})
+       (f)
+       (message {:op :eval
+                 :code (nrepl/code :cljs/quit)})))))
+
+(t/use-fixtures :each piggieback-fixture)
+
+(t/deftest sanity
+  (t/testing "cljs repl is active"
+    (let [response (message {:op :eval
+                             :code (nrepl/code js/console)})]
+      (t/is (= "cljs.user" (:ns response)))
+      (t/is (= #{"done"} (:status response)))))
+
+  (t/testing "eval works"
+    (let [response (message {:op :eval
+                             :code (nrepl/code (map even? (range 6)))})]
+      (t/is (= "cljs.user" (:ns response)))
+      (t/is (= ["(true false true false true false)"] (:value response)))
+      (t/is (= #{"done"} (:status response)))))
+
+  (t/testing "errors handled properly"
+    (let [response (message {:op :eval
+                             :code (nrepl/code (ffirst 1))})]
+      (t/is (= "class clojure.lang.ExceptionInfo"
+               (:ex response)
+               (:root-ex response)))
+      (t/is (string? (:err response)))
+      (t/is (= #{"eval-error" "done"} (:status response))))))
+
+(t/deftest resolve-missing-test
+  (t/testing "Finds functions is regular namespaces"
+    (let [response (message {:op :resolve-missing :symbol 'print-doc})
+          [[namespace type]] (edn/read-string (:candidates response))]
+      (t/is (= 'cljs.repl namespace))
+      (t/is (= :ns type)))
+    (t/testing "Finds macros"
+      (let [response (message {:op :resolve-missing :symbol 'dir})
+            [[namespace type]] (edn/read-string (:candidates response))]
+        (t/is (= 'cljs.repl namespace))
+        (t/is (= :macro type))))))


### PR DESCRIPTION
For now this only handles macros and regular cljs vars.  Adding support
google closure classes will be tackled later.

