### PR TITLE
Teach clean-ns how to handle cljc files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+* Add cljc support to `clean-ns`.
+* Add cljs support to `clean-ns`.
 * `rename-file-or-dir` now knows how to move cljs files.
 * The `artifact-version` list is now sorted.
 * Add `namespace-aliases` which provides a mapping of the namespace aliases that are in use in the project.

--- a/src/refactor_nrepl/ns/pprint.clj
+++ b/src/refactor_nrepl/ns/pprint.clj
@@ -2,7 +2,8 @@
   (:require [clojure
              [pprint :refer [pprint]]
              [string :as str]]
-            [refactor-nrepl.ns.helpers :as helpers :refer [prefix-form?]]))
+            [refactor-nrepl.ns.helpers :as helpers :refer [prefix-form?]]
+            [rewrite-clj.zip :as zip]))
 
 (defn- libspec-vectors-last [libspecs]
   (vec (concat (remove sequential? libspecs)

--- a/src/refactor_nrepl/util.clj
+++ b/src/refactor_nrepl/util.clj
@@ -1,13 +1,12 @@
 (ns refactor-nrepl.util
-  (:require [clojure.java.classpath :as cp]
-            [clojure
-             [set :as set]
-             [string :as str]
-             [walk :as walk]]
+  (:require [clojure.java
+             [classpath :as cp]
+             [io :as io]]
             [clojure.tools.analyzer.ast :refer [nodes]]
-            [clojure.tools.namespace.find :as find]
             [clojure.tools.namespace
+             [find :as find]
              [parse :refer [read-ns-decl]]]
+            [clojure.walk :as walk]
             [me.raynes.fs :as fs]
             [rewrite-clj.zip :as zip])
   (:import [java.io File PushbackReader]
@@ -49,21 +48,35 @@
   (filter pred (file-seq dir)))
 
 (defn cljc-file?
-  [^File f]
-  (.endsWith (.getPath f) ".cljc"))
+  [path-or-file]
+  (.endsWith (.getPath (io/file path-or-file)) ".cljc"))
 
 (defn cljs-file?
-  [^File f]
-  (.endsWith (.getPath f) ".cljs"))
+  [path-or-file]
+  (.endsWith (.getPath (io/file path-or-file)) ".cljs"))
 
 (defn clj-file?
-  [^File f]
-  (.endsWith (.getPath f) ".clj"))
+  [path-or-file]
+  (.endsWith (.getPath (io/file path-or-file)) ".clj"))
 
 (defn source-file?
   "True for clj, cljs or cljc files."
-  [^File f]
-  ((some-fn cljc-file? cljs-file? clj-file?) f))
+  [path-or-file]
+  ((some-fn cljc-file? cljs-file? clj-file?) (io/file path-or-file)))
+
+
+(defn file->dialect
+  "Return the clojure dialect used in the file f.
+
+  The dialect is either :clj, :cljs or :cljc."
+  [path-or-file]
+  (let [f (io/file path-or-file)]
+    (cond
+      (clj-file? f) :clj
+      (cljs-file? f) :cljs
+      (cljc-file? f) :cljc
+      :else (throw (ex-info "Path isn't pointing to file in a clj dialect!"
+                            {:path path-or-file})))))
 
 (defn filter-project-files
   "Return the files in the project satisfying (pred ^File file)."
@@ -216,3 +229,11 @@
      ~@body
      (catch clojure.lang.ExceptionInfo e#
        (throw (apply ex-info-assoc e# ~kvs)))))
+
+(defn conj-some
+  "Like conj but nil values are discared from xs."
+  [coll & xs]
+  (let [xs (remove nil? xs)]
+    (if (seq xs)
+      (apply conj coll xs)
+      coll)))

--- a/test/resources/cljcns.cljc
+++ b/test/resources/cljcns.cljc
@@ -1,0 +1,87 @@
+(ns resources.cljcns
+  "This is a docstring for the ns"
+  {:author "Winnie the pooh"}
+  (:refer-clojure :exclude [macroexpand-1 read read-string])
+  #?@(:clj
+      [(:require
+        [clojure.instant :as inst :refer [read-instant-date] :reload true]
+        [clojure.walk :refer [prewalk postwalk]]
+        (clojure data edn)
+        [clojure.pprint :refer [get-pretty-writer formatter cl-format]]
+        clojure.test.junit
+        [clojure.xml])
+       (:use clojure.test
+             clojure.test
+             [clojure.string :rename {replace foo reverse bar} :reload-all true :reload true])
+       (:import java.util.Random
+                java.io.PushbackReader
+                java.io.PushbackReader
+                java.io.FilenameFilter
+                java.io.Closeable
+                [java.util Date Date Calendar]
+                (java.util Date Calendar))]
+      :cljs
+      [(:require [cljs.test :refer-macros [is deftest]]
+                 [cljs.test :refer-macros [is]]
+                 [clojure.string :refer [split-lines join]]
+                 [cljs.pprint :as pprint]
+                 [clojure.set :as set])
+       (:require-macros [cljs.test :refer [testing]]
+                        [cljs.analyzer.macros :as am]
+                        cljs.analyzer.api)
+       (:use-macros [cljs.test :only [run-tests]])
+       (:import goog.string)]))
+
+#?(:cljs
+   (do
+     (defn use-some-of-it []
+       (pprint/pprint {:foo :bar})
+       (set/intersection #{1 2} #{1})
+       (split-lines "ok"))
+
+     (deftest tt
+       (testing "whatever"
+         (is (= 1 1))))
+
+     (defn foo []
+       `(join "foo bar"))
+
+     (fn []
+       (run-tests))
+
+     (string/regExpEscape "ok")
+
+     (am/with-core-macros "fake/path"
+       :ignore)
+
+     (cljs.analyzer.api/no-warn
+      :body))
+   :clj
+   (do
+     (defmacro tt [writer]
+       (Random.)
+       `(get-pretty-writer ~writer))
+
+     (defmacro black-hole [& body])
+
+     (black-hole
+      (prewalk identity [1 2 3])
+      (postwalk identity [3 2 1]))
+
+     (defn use-everything [^Closeable whatever]
+       (cl-format)
+       (formatter nil)
+       (compose-fixtures)
+       (clojure.test.junit/with-junit-output "")
+       (escape)
+       (inst/read-instant-date)
+       (clojure.data/diff)
+       (clojure.edn/read-string)
+       (clojure.xml/emit "")
+       (Date.)
+       (Calendar/getInstance)
+       (PushbackReader. nil))
+
+     (proxy [FilenameFilter] []
+       (accept [d n] true))
+     ))

--- a/test/resources/cljcns_cleaned.cljc
+++ b/test/resources/cljcns_cleaned.cljc
@@ -1,0 +1,24 @@
+(ns resources.cljcns
+  "This is a docstring for the ns"
+  {:author "Winnie the pooh"}
+  (:refer-clojure :exclude [macroexpand-1 read read-string])
+  #?@(:clj
+      [(:require clojure.data clojure.edn
+                 [clojure.instant :as inst :reload true]
+                 [clojure.pprint :refer [cl-format formatter get-pretty-writer]]
+                 [clojure.string :refer :all :rename {replace foo reverse bar} :reload-all true]
+                 [clojure.test :refer :all]
+                 clojure.test.junit
+                 [clojure.walk :refer [postwalk prewalk]]
+                 clojure.xml)
+       (:import [java.io Closeable FilenameFilter PushbackReader]
+                [java.util Calendar Date Random])]
+      :cljs
+      [(:require [cljs.pprint :as pprint]
+                 [cljs.test :refer-macros [deftest is]]
+                 [clojure.set :as set]
+                 [clojure.string :refer [join split-lines]])
+       (:require-macros cljs.analyzer.api
+                        [cljs.analyzer.macros :as am]
+                        [cljs.test :refer [run-tests testing]])
+       (:import goog.string)]))


### PR DESCRIPTION
This works but it's not as pretty as I'd like.

There are no pretty printing facilities for cljc files, and I'm not
motivated to write any, so the ns is printed using
`clojure.pprint/pprint`.

The simplest thing was to wrap all the dependency forms of each language in
a reader macro.  This makes editing, and reading, very easy, but the ns
form now contains far more duplication than is strictly necessary.

The option to do `prefix-rewriting` is now ignored in cljc files.  I
felt this was a good idea because cljs doesn't have the prefix notation
and it would look weird (and complicate matters) if we didn't preserve
symmetry.

The ns looks like this:

```
(ns my-namespace
   #?@
   (:clj
    [(:require
       [clojure.walk :as walk]
       .
       .
       .
                              ])
    :cljs
    [(:require [cljs.test :refer-macros [is deftest]]
    .
    .
    .
                             ])))
```