### PR TITLE
Fix find symbol in refer regression

### DIFF
--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -3,6 +3,7 @@
             [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.namespace.parse :as parse]
+            [clojure.tools.reader.reader-types :as readers]
             [me.raynes.fs :as fs]
             [refactor-nrepl.util :refer [normalize-to-unix-path]])
   (:import [java.io File FileReader PushbackReader StringReader]))
@@ -175,12 +176,14 @@ type is a toplevel keyword in the ns form e.g. :require or :use."
   Dialect is either :clj or :cljs."
   ([path]
    (with-open [file-reader (FileReader. path)]
-     (if-let [ns-form (parse/read-ns-decl (PushbackReader. file-reader))]
+     (if-let [ns-form (parse/read-ns-decl (readers/indexing-push-back-reader
+                                           (PushbackReader. file-reader)))]
        ns-form
        (throw (IllegalStateException. (str "No ns form at " path))))))
   ([dialect path]
    (with-open [file-reader (FileReader. path)]
-     (if-let [ns-form (parse/read-ns-decl (PushbackReader. file-reader)
+     (if-let [ns-form (parse/read-ns-decl (readers/indexing-push-back-reader
+                                           (PushbackReader. file-reader))
                                           {:read-cond :allow :features #{dialect}})]
        ns-form
        (throw (IllegalStateException. (str "No ns form at " path)))))))

--- a/src/refactor_nrepl/middleware.clj
+++ b/src/refactor_nrepl/middleware.clj
@@ -1,27 +1,23 @@
 (ns refactor-nrepl.middleware
-  (:require [cider.nrepl.middleware.util
-             [cljs :as cljs]
-             [misc :refer [err-info]]]
-            [clojure.tools.nrepl
-             [middleware :refer [set-descriptor!]]
-             [misc :refer [response-for]]
-             [transport :as transport]]
-            [refactor-nrepl
-             [analyzer :refer [warm-ast-cache]]
-             [artifacts :refer [artifact-list artifact-versions hotload-dependency]]
-             [config :as config]
-             [extract-definition :refer [extract-definition]]
-             [plugin :as plugin]
-             [rename-file-or-dir :refer [rename-file-or-dir]]
-             [stubs-for-interface :refer [stubs-for-interface]]]
-            [refactor-nrepl.find
-             [find-symbol :refer [find-symbol]]
-             [find-locals :refer [find-used-locals]]]
-            [refactor-nrepl.ns
-             [clean-ns :refer [clean-ns]]
-             [namespace-aliases :refer [namespace-aliases]]
-             [pprint :refer [pprint-ns]]
-             [resolve-missing :refer [resolve-missing]]]))
+  (:require [cider.nrepl.middleware.util.cljs :as cljs]
+            [cider.nrepl.middleware.util.misc :refer [err-info]]
+            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+            [clojure.tools.nrepl.misc :refer [response-for]]
+            [clojure.tools.nrepl.transport :as transport]
+            [refactor-nrepl.analyzer :refer [warm-ast-cache]]
+            [refactor-nrepl.artifacts :refer
+             [artifact-list artifact-versions hotload-dependency]]
+            [refactor-nrepl.config :as config]
+            [refactor-nrepl.extract-definition :refer [extract-definition]]
+            [refactor-nrepl.find.find-locals :refer [find-used-locals]]
+            [refactor-nrepl.find.find-symbol :refer [find-symbol]]
+            [refactor-nrepl.ns.clean-ns :refer [clean-ns]]
+            [refactor-nrepl.ns.libspecs :refer [namespace-aliases]]
+            [refactor-nrepl.ns.pprint :refer [pprint-ns]]
+            [refactor-nrepl.ns.resolve-missing :refer [resolve-missing]]
+            [refactor-nrepl.plugin :as plugin]
+            [refactor-nrepl.rename-file-or-dir :refer [rename-file-or-dir]]
+            [refactor-nrepl.stubs-for-interface :refer [stubs-for-interface]]))
 
 (defmacro ^:private with-errors-being-passed-on [transport msg & body]
   `(try

--- a/test/refactor_nrepl/ns/namespace_aliases_test.clj
+++ b/test/refactor_nrepl/ns/namespace_aliases_test.clj
@@ -1,7 +1,7 @@
 (ns refactor-nrepl.ns.namespace-aliases-test
   (:require [clojure.test :as t]
             [refactor-nrepl.core :as core]
-            [refactor-nrepl.ns.namespace-aliases :as sut]
+            [refactor-nrepl.ns.libspecs :as sut]
             [refactor-nrepl.util :as util]))
 
 (t/deftest finds-the-aliases-in-this-ns
@@ -38,11 +38,11 @@
 
 (t/deftest libspecs-are-cached
   (sut/namespace-aliases)
-  (with-redefs [refactor-nrepl.ns.namespace-aliases/put-cached-libspec
+  (with-redefs [refactor-nrepl.ns.libspecs/put-cached-libspec
                 (fn [& _] (throw (ex-info "Cache miss!" {})))]
     (t/is (sut/namespace-aliases)))
   (reset! @#'sut/cache {})
-  (with-redefs [refactor-nrepl.ns.namespace-aliases/put-cached-libspec
+  (with-redefs [refactor-nrepl.ns.libspecs/put-cached-libspec
                 (fn [& _] (throw (Exception. "Expected!")))]
     (t/is (thrown-with-msg? Exception #"Expected!"
                             (sut/namespace-aliases)))))


### PR DESCRIPTION
- renames `ns.namespace-aliases` to `ns.libspecs`
- uses indexing pushback reader when parsing the ns from so the location
  info is recorded/retained
- gets rid of the temp directory for integration tests