### PR TITLE
More relaxed with invalid code

### DIFF
--- a/src/refactor_nrepl/analyzer.clj
+++ b/src/refactor_nrepl/analyzer.clj
@@ -99,14 +99,7 @@
   [file-content]
   (let [ast-or-err (cachable-ast file-content)
         error? (instance? Throwable ast-or-err)
-        debug (:debug config/*config*)
-        first-level-errors (and (coll? ast-or-err)
-                                (->> (map :result ast-or-err)
-                                     (remove nil?)
-                                     (filter #(.. (type %)
-                                                  (getName)
-                                                  (endsWith "clojure.tools.analyzer.jvm.ExceptionThrown")))
-                                     seq))]
+        debug (:debug config/*config*)]
 
     (cond
       (and error? debug)
@@ -114,13 +107,6 @@
 
       error?
       (throw-ast-in-bad-state file-content (.getMessage ast-or-err))
-
-      (and first-level-errors debug)
-      (throw (.-e (first first-level-errors)))
-
-      first-level-errors
-      (throw-ast-in-bad-state file-content (str/join "; " (->> (map #(.-e %) first-level-errors)
-                                                               (map #(.getMessage %)))))
 
       :default
       ast-or-err)))

--- a/src/refactor_nrepl/find/find_symbol.clj
+++ b/src/refactor_nrepl/find/find_symbol.clj
@@ -102,13 +102,13 @@
          (str/join "\n")
          str/trim)))
 
-(defn- find-symbol-in-file [fully-qualified-name block-on-errors file]
+(defn- find-symbol-in-file [fully-qualified-name ignore-errors file]
   (let [file-content (slurp file)
         locs (try (->> (ana/ns-ast file-content)
                        (find-symbol-in-ast fully-qualified-name)
                        (filter :line-beg))
                   (catch Exception e
-                    (when block-on-errors
+                    (when-not ignore-errors
                       (throw e))))
         locs (concat locs
                      (some->
@@ -129,7 +129,7 @@
                                   (:line-end  info))}))]
     (map gather locs)))
 
-(defn- find-global-symbol [file ns var-name clj-dir block-on-errors]
+(defn- find-global-symbol [file ns var-name clj-dir ignore-errors]
   (let [dir (or clj-dir ".")
         namespace (or ns (core/ns-from-string (slurp file)))
         fully-qualified-name (if (= namespace "clojure.core")
@@ -137,7 +137,7 @@
                                (str/join "/" [namespace var-name]))]
     (->> dir
          (core/find-in-dir (some-fn core/clj-file? core/cljc-file?))
-         (mapcat (partial find-symbol-in-file fully-qualified-name block-on-errors)))))
+         (mapcat (partial find-symbol-in-file fully-qualified-name ignore-errors)))))
 
 (defn- get&read-enclosing-sexps
   [file-content {:keys [line-beg col-beg]}]
@@ -249,10 +249,10 @@
       (not= (core/suffix thing-in-file)
             (core/suffix name)))))
 
-(defn find-symbol [{:keys [file ns name dir line column block-on-errors]}]
+(defn find-symbol [{:keys [file ns name dir line column ignore-errors]}]
   (core/throw-unless-clj-file file)
   (let [macros (future (find-macro (core/fully-qualify name ns)))
-        globals (->> (find-global-symbol file ns name dir (= block-on-errors "true"))
+        globals (->> (find-global-symbol file ns name dir (= ignore-errors "true"))
                      distinct
                      (remove spurious?)
                      future)]


### PR DESCRIPTION
Default to ignore errors for `find symbol`. This results `find usages`, `rename symbol` and `inline symbol` to work even if there is a broken ns in the project.

Also exploit some `tools.analzyer` AST validation hooks so namespaces with type errors, unresolved symbols or possible arity problems will be still analyzed.

`clj-refactor.el` (and other clients) will need a `cljr-block-on-analyzer-errors` so strictness loving users can block above features on AST problems.

this PR is basically a result of a discussion on 6th Oct between @expez @Malabarba and myself on gitter