### PR TITLE
Find used publics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New features
+
+* Add `find-used-publics` which list occurrences of symbols defined in namespace A in namespace B.
+
 ## 2.0.0
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This op finds occurrences of a single symbol.
 
 `ns` The ns where the symbol is defined.
 
-`name` The name of the symbol
+`name` The name of the symbol.
 
 `line` The line number where the symbol occurrs, counting from 1.
 
@@ -142,7 +142,7 @@ Pretty-printing the `(ns ..)` form is surprisingly difficult.  The current imple
 
 In the event of an error `clean-ns` will return `error` which is an error message intended for display to the user.
 
-**Warning**: The `clean -ns` op dependes on `tools.analyzer` to determine which vars in a file are actually being used.  This means the code is evaluated and any top-level occurrences of `(launch-missiles)` should be avoided.
+**Warning**: The `clean-ns` op dependes on `tools.analyzer` to determine which vars in a file are actually being used.  This means the code is evaluated and any top-level occurrences of `(launch-missiles)` should be avoided.
 
 This op can be [configured](#configuration).
 
@@ -267,6 +267,16 @@ project. The reply looks like this:
  :cljs {set (clojure.set), pprint (cljs.pprint)}}
 ```
 The list of suggestions is sorted by frequency in decreasing order, so the first element is always the best suggestion.
+
+### find-used-publics
+
+In case namespace B depends on namespace A this operation finds occurrences of symbols in namespace B defined in namespace A.
+
+`file` The absolute path to the file being analyzed (namespace B).
+
+`used-ns` The namespace that defines symbols we are searching for (namespace A).
+
+Possible application of this operation to refactor a `:refer :all` style require into a refer or aliased style require.
 
 ### Errors
 

--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -7,7 +7,7 @@
             [me.raynes.fs :as fs]
             [refactor-nrepl.util :refer [normalize-to-unix-path]]
             [refactor-nrepl.s-expressions :as sexp])
-  (:import [java.io File FileReader PushbackReader StringReader]))
+  (:import [java.io FileReader PushbackReader StringReader]))
 
 (defn version []
   (let [v (-> (or (io/resource "refactor-nrepl/refactor-nrepl/project.clj")
@@ -303,3 +303,7 @@
               (str "Can't create a fully qualified symbol from: '" prefix
                    "' and  '" suffix "'"))))
     (str prefix "/" suffix)))
+
+(defn normalize-var-name
+  [sym-str]
+  (str/replace sym-str #"#'.*/" ""))

--- a/src/refactor_nrepl/find/find_symbol.clj
+++ b/src/refactor_nrepl/find/find_symbol.clj
@@ -2,7 +2,6 @@
   (:require [clojure
              [set :as set]
              [string :as str]]
-            [clojure.java.io :as io]
             [clojure.tools.analyzer.ast :refer [nodes postwalk]]
             [clojure.tools.namespace.parse :as parse]
             [refactor-nrepl
@@ -10,6 +9,7 @@
              [core :as core]
              [s-expressions :as sexp]]
             [refactor-nrepl.find.find-macros :refer [find-macro]]
+            [refactor-nrepl.find.util :as find-util]
             [refactor-nrepl.ns.libspecs :as libspecs]))
 
 (def ^:private symbol-regex #"[\w\.:\*\+\-_!\?]+")
@@ -232,33 +232,16 @@
   [{:keys [line-beg line-end col-beg col-end name file match]}]
   [line-beg line-end col-beg col-end name file match])
 
-(defn- spurious?
-  "True if the occurrence doesn't exist at the given coordinates."
-  [{:keys [file line-beg col-beg col-end name match] :as occ}]
-  ;; coordinates are wrong for def forms, they match the beginning of
-  ;; the form not the first mention of the symbol being defined
-  (when-not (.startsWith match "(def")
-    (let [thing-in-file (->> file
-                             io/reader
-                             line-seq
-                             (drop (dec line-beg))
-                             first
-                             (drop (dec col-beg))
-                             (take (- col-end col-beg))
-                             (apply str))]
-      (not= (core/suffix thing-in-file)
-            (core/suffix name)))))
-
 (defn find-symbol [{:keys [file ns name dir line column ignore-errors]}]
   (core/throw-unless-clj-file file)
   (let [macros (future (find-macro (core/fully-qualify ns name)))
         globals (->> (find-global-symbol file ns name dir (= ignore-errors "true"))
                      distinct
-                     (remove spurious?)
+                     (remove find-util/spurious?)
                      future)]
     (or
      ;; find-local-symbol is the fastest of the three
-     (not-empty (remove spurious? (distinct (find-local-symbol file name line column))))
+     (not-empty (remove find-util/spurious? (distinct (find-local-symbol file name line column))))
      ;; find-macros has to be checked first because find-global-symbol
      ;; can return spurious hits for some macro definitions
      @macros

--- a/src/refactor_nrepl/find/find_used_publics.clj
+++ b/src/refactor_nrepl/find/find_used_publics.clj
@@ -1,0 +1,75 @@
+(ns refactor-nrepl.find.find-used-publics
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.tools.analyzer.ast :refer [nodes]]
+            [refactor-nrepl.analyzer :as ana]
+            [refactor-nrepl.find.find-macros :as macros]
+            [refactor-nrepl.find.util :as find-util]
+            [refactor-nrepl.core :as core]))
+
+(defn- ns-used-in-node?
+  [used-ns ast-node]
+  (= (the-ns (symbol used-ns)) (-> ast-node :meta :ns)))
+
+(defn- normalize-protocol-name
+  [protocol-name-str]
+  (-> (str/replace protocol-name-str #"interface\s+" "")
+      (str/replace "/" ".")
+      (str/replace "#'" "")
+      (str/replace "-" "_")))
+
+(defn- node->loc-info [file symbol-name-pred node]
+  (->> ((juxt (comp :line :env)
+              (comp :end-line :env)
+              (comp :column :env)
+              (comp :end-column :env)
+              (constantly file)
+              symbol-name-pred)
+        node)
+       (zipmap [:line-beg :line-end :col-beg :col-end :file :name])))
+
+(defn- protocol-used-in-node?
+  [used-ns node]
+  (let [ns-protocols (->> (symbol used-ns)
+                          ns-publics
+                          (filter (comp :method-builders deref val))
+                          (map val)
+                          (map str)
+                          (map normalize-protocol-name)
+                          set)]
+    (some ns-protocols (->> (:interfaces node)
+                            (map str)
+                            (map normalize-protocol-name)))))
+
+(defn- normalize-loc-info-name
+  [norm-fn loc-info]
+  (update-in loc-info [:name] norm-fn))
+
+(defn- find-used-protocols
+  [file used-ns ast-nodes]
+  (let [protocol-pred (partial protocol-used-in-node? used-ns)]
+    (->> (filter :interfaces ast-nodes)
+         (filter protocol-pred)
+         (map (partial node->loc-info file protocol-pred))
+         (map (partial normalize-loc-info-name #(str/replace % #".*\." ""))))))
+
+(defn- find-used-vars
+  [file used-ns ast-nodes]
+  (->> (filter (partial ns-used-in-node? used-ns) ast-nodes)
+       (map (partial node->loc-info file :var))
+       (remove (partial find-util/spurious? file))
+       (map (partial normalize-loc-info-name core/normalize-var-name))))
+
+(defn find-used-publics
+  "Returns used symbols of the namespace given as `used-ns` in the file.
+
+  Looks for used symbol types: vars, protocols and macros."
+  [{:keys [file used-ns]}]
+  (let [ast-nodes (->> (slurp file)
+                       ana/ns-ast
+                       rest
+                       (mapcat nodes))
+        macros (future (macros/find-used-macros file used-ns))
+        vars (future (find-used-vars file used-ns ast-nodes))
+        protocols (future (find-used-protocols file used-ns ast-nodes))]
+    (set/union @vars @protocols @macros)))

--- a/src/refactor_nrepl/find/util.clj
+++ b/src/refactor_nrepl/find/util.clj
@@ -1,0 +1,22 @@
+(ns refactor-nrepl.find.util
+  (:require [clojure.java.io :as io]
+            [refactor-nrepl.core :as core]))
+
+(defn spurious?
+  "True if the occurrence doesn't exist at the given coordinates."
+  ([{:keys [file line-beg col-beg col-end name match] :as occ}]
+   ;; coordinates are wrong for def forms, they match the beginning of
+   ;; the form not the first mention of the symbol being defined
+   (when-not (and match (.startsWith match "(def"))
+     (let [thing-in-file (->> file
+                              io/reader
+                              line-seq
+                              (drop (dec line-beg))
+                              first
+                              (drop (dec col-beg))
+                              (take (- col-end col-beg))
+                              (apply str))]
+       (not= (core/suffix thing-in-file)
+             (core/suffix name)))))
+  ([file occ]
+   (spurious? (assoc occ :file file))))

--- a/test/refactor_nrepl/find/find_macros_test.clj
+++ b/test/refactor_nrepl/find/find_macros_test.clj
@@ -50,7 +50,7 @@
   (with-redefs [refactor-nrepl.find.find-macros/put-cached-macro-definitions
                 (fn [& _] (throw (ex-info "Cache miss!" {})))]
     (is (found? #"defmacro my-macro" (find-macro "com.example.macro-def/my-macro"))))
-  (reset! @#'refactor-nrepl.find.find-macros/cache {})
+  (reset! @#'refactor-nrepl.find.find-macros/macro-defs-cache {})
   (with-redefs [refactor-nrepl.find.find-macros/put-cached-macro-definitions
                 (fn [& _] (throw (Exception. "Expected!")))]
     (is (thrown-with-msg? Exception #"Expected!"

--- a/test/refactor_nrepl/find/find_used_publics_test.clj
+++ b/test/refactor_nrepl/find/find_used_publics_test.clj
@@ -1,0 +1,26 @@
+(ns refactor-nrepl.find.find-used-publics-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is]]
+            [refactor-nrepl.find.find-used-publics :as fup]))
+
+(defn- absolute-path [^String path]
+  (.getAbsolutePath (io/file path)))
+
+(def ns2-path (absolute-path "test/resources/ns2.clj"))
+(def macro-usage (absolute-path "test/resources/testproject/src/com/example/referred_macro_usage.clj"))
+(def protocol-usage (absolute-path "test/resources/testproject/src/com/example/protocol_usage.clj"))
+
+(deftest finds-symbols-of-ns
+  (is (= '("get-pretty-writer" "fresh-line" "cl-format")
+         (->> (fup/find-used-publics {:file ns2-path :used-ns "clojure.pprint"})
+              (map :name)))))
+
+(deftest finds-macros-of-ns
+  (is (= '("my-macro")
+         (->> (fup/find-used-publics {:file macro-usage :used-ns "com.example.macro-def"})
+              (map :name)))))
+
+(deftest find-protocols-of-ns
+  (is (= '("MyProtocol" "MyProtocol")
+         (->> (fup/find-used-publics {:file protocol-usage :used-ns "com.example.protocol-def"})
+              (map :name)))))

--- a/test/resources/testproject/src/com/example/protocol_def.clj
+++ b/test/resources/testproject/src/com/example/protocol_def.clj
@@ -1,0 +1,4 @@
+(ns com.example.protocol-def)
+
+(defprotocol MyProtocol
+  (my-fn [arg0] "my-fn docstring"))

--- a/test/resources/testproject/src/com/example/protocol_usage.clj
+++ b/test/resources/testproject/src/com/example/protocol_usage.clj
@@ -1,0 +1,12 @@
+(ns com.example.protocol-usage
+  (:require [com.example.protocol-def :refer :all]))
+
+(defrecord MyRecord []
+  MyProtocol
+  (my-fn [arg]
+    (println arg)))
+
+(deftype MyType []
+  MyProtocol
+  (my-fn [arg]
+    (println arg)))


### PR DESCRIPTION
Finds used publics of namespace A in namespace B. Returns find symbol
like occurrences result. Intended to use for replace refer all. Finds
vars, protocols and macros.

Also adds macro occurrences cache and warm-macro-occurrences-cache.
This is supposed to be warmed at REPL startup by default just like
the AST cache.

Intended to be merged for version 2.1.0