### PR TITLE
Fix resolve-missing for cljs

### DIFF
--- a/src/refactor_nrepl/ns/resolve_missing.clj
+++ b/src/refactor_nrepl/ns/resolve_missing.clj
@@ -42,17 +42,17 @@
   (let [all-ns (remove (partial = 'cljs.core) (keys (cljs-ana/all-ns env)))
         ns-by-vars (->> all-ns
                         (mapcat (fn [ns]
-                                  (map (fn [sym] {sym {:name ns :type :ns}})
+                                  (map (fn [sym] {sym (list {:name ns :type :ns})})
                                        (ns-publics-cljs env ns))))
                         (remove empty?)
-                        (reduce merge))
+                        (apply merge-with into))
         ns-by-macros (->> all-ns
                           (mapcat (fn [ns]
-                                    (map (fn [sym] {sym {:name ns :type :macro}})
+                                    (map (fn [sym] {sym (list {:name ns :type :macro})})
                                          (ns-public-macros-cljs ns))))
                           (remove empty?)
-                          (reduce merge))]
-    (merge ns-by-vars ns-by-macros)))
+                          (apply merge-with into))]
+    (merge-with into ns-by-vars ns-by-macros)))
 
 (defn resolve-missing [{sym :symbol :as msg}]
   (when (or (not (string? sym)) (str/blank? sym))

--- a/test/refactor_nrepl/ns/resolve_missing_test.clj
+++ b/test/refactor_nrepl/ns/resolve_missing_test.clj
@@ -70,7 +70,7 @@
 (t/deftest resolve-missing-test
   (t/testing "Finds functions is regular namespaces"
     (let [{:keys [error] :as response} (message {:op :resolve-missing :symbol 'print-doc})
-          {:keys [name type]} (edn/read-string (:candidates response))]
+          {:keys [name type]} (first (edn/read-string (:candidates response)))]
       (when error
         (println error)
         (throw (RuntimeException. error)))
@@ -78,7 +78,7 @@
       (t/is (= :ns type)))
     (t/testing "Finds macros"
       (let [{:keys [error] :as response} (message {:op :resolve-missing :symbol 'dir})
-            {:keys [name type]} (edn/read-string (:candidates response))]
+            {:keys [name type]} (first (edn/read-string (:candidates response)))]
         (when error
           (throw (RuntimeException. error)))
         (t/is (= 'cljs.repl name))


### PR DESCRIPTION
Resolve-missing returns a list of candidates. Before this fix, the
cljs-path returned only a single candidate. That's because every
candidate was merged together. We now use `merge-with into` to generate
a list of candidates instead.