### PR TITLE
Add support for skipping excluded dependencies

### DIFF
--- a/src/refactor_nrepl/plugin.clj
+++ b/src/refactor_nrepl/plugin.clj
@@ -16,15 +16,17 @@
       (lein/warn (str "Warning: refactor-nrepl requires " artifact " "
                       version-string " or greater."))))
 
-(defn- external-dependencies-ok? [dependencies]
-  (reduce (fn [acc [artifact version-string]]
-            (and (version-ok? dependencies artifact version-string) acc))
-          true
-          external-dependencies))
+(defn- external-dependencies-ok? [dependencies exclusions]
+  (let [exclusions (set exclusions)]
+    (reduce (fn [acc [artifact version-string]]
+              (or (exclusions artifact)
+                  (and (version-ok? dependencies artifact version-string) acc)))
+            true
+            external-dependencies)))
 
 (defn middleware
-  [{:keys [dependencies] :as project}]
-  (if (external-dependencies-ok? dependencies)
+  [{:keys [dependencies exclusions] :as project}]
+  (if (external-dependencies-ok? dependencies exclusions)
     (-> project
         (update-in [:dependencies]
                    (fnil into [])


### PR DESCRIPTION
This patch tweaks the dependency checker, so that refactor-nrepl will activate itself normally if one of its dependencies is listed in a project's :exclusions. This enables a user to for instance exclude
org.clojure/clojure and provide a fork, thus taking on all responsibility for providing an adequate version.