### PR TITLE
Config setting for exceptional libspecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ install.cmd
 /.cljs_rhino_repl/
 /.cljs_node_repl/
 /out/
+/.lein-env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#160](https://github.com/clojure-emacs/refactor-nrepl/issues/160) Make `resolve-missing` find newly defined vars and types (clj). Because of a stale cache, newly added vars or types would not be found. This fix takes into account vars/types added by eval-ing code (rescan affected namespace), and by hotloading dependencies (reset the cache).
 
+### New features
+
+* New config setting `:libspec-whitelist` which makes it possible to create a seq of namespaces `clean-ns` shouldn't prune.  This is useful for libspecs which aren't used except through side-effecting loads.
+
 ## 2.2.0
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -44,14 +44,21 @@ Configuration settings are passed along with each msg, currently the recognized 
  ;; Verbose setting for debugging.  The biggest effect this has is
  ;; to not catch any exceptions to provide meaningful error
  ;; messages for the client.
+
  :debug false
 
- ;; When true clean-ns will remove unused symbols, otherwise just
+ ;; When true `clean-ns` will remove unused symbols, otherwise just
  ;; sort etc
  :prune-ns-form true
 
- ;; Should clean-ns favor prefix forms in the ns macro?
+ ;; Should `clean-ns` favor prefix forms in the ns macro?
  :prefix-rewriting true
+
+ ;; Some libspecs are side-effecting and shouldn't be pruned by `clean-ns`
+ ;; even if they're otherwise unused.
+ ;; This seq of strings will be used as regexp patterns to match
+ ;; against the libspec name.
+ :libspec-whitelist ["^cljsjs"]
 }
 ```
 

--- a/src/refactor_nrepl/config.clj
+++ b/src/refactor_nrepl/config.clj
@@ -9,12 +9,18 @@
 
    :debug false
 
-   ;; When true clean-ns will remove unused symbols, otherwise just
+   ;; When true `clean-ns` will remove unused symbols, otherwise just
    ;; sort etc
    :prune-ns-form true
 
-   ;; Should clean-ns favor prefix forms in the ns macro?
+   ;; Should `clean-ns` favor prefix forms in the ns macro?
    :prefix-rewriting true
+
+   ;; Some libspecs are side-effecting and shouldn't be pruned by `clean-ns`
+   ;; even if they're otherwise unused.
+   ;; This seq of strings will be used as regexp patterns to match
+   ;; against the libspec name.
+   :libspec-whitelist ["^cljsjs"]
    })
 
 (defn opts-from-msg [msg]


### PR DESCRIPTION
Some libspecs are side-effecting at load time but appear to be unused
otherwise.  `clean-ns` will need a list of these to ignore.  As such
namespaces might be user-created, and I don't want the responsibility of
maintaining a curated list of every such occurrence, this has to be
user-editable.