### PR TITLE
Add dirty namespace tracking for resolve-missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bugs fixed
+
+* [#160](https://github.com/clojure-emacs/refactor-nrepl/issues/160) Make `resolve-missing` find newly defined vars and types (clj). Because of a stale cache, newly added vars or types would not be found. This fix takes into account vars/types added by eval-ing code (rescan affected namespace), and by hotloading dependencies (reset the cache).
+
 ## 2.2.0
 
 ### New features

--- a/src/refactor_nrepl/artifacts.clj
+++ b/src/refactor_nrepl/artifacts.clj
@@ -8,6 +8,7 @@
             [clojure.tools.namespace.find :as find]
             [org.httpkit.client :as http]
             [refactor-nrepl.ns.slam.hound.search :as slamhound]
+            [refactor-nrepl.ns.slam.hound.regrow :as slamhound-regrow]
             [version-clj.core :as versions])
   (:import java.util.Date
            java.util.jar.JarFile))
@@ -120,7 +121,8 @@
           ;; A failure here isn't a big deal, it only means that resolve-missing
           ;; isn't going to work until the namespace has been loaded manually.
           )))
-    (slamhound/reset)))
+    (slamhound/reset)
+    (slamhound-regrow/clear-cache!)))
 
 (defn- ensure-quality-coordinates [coordinates]
   (let [coords (->> coordinates read-string (take 2) vec)]

--- a/test/refactor_nrepl/ns/resolve_missing_caching_test.clj
+++ b/test/refactor_nrepl/ns/resolve_missing_caching_test.clj
@@ -1,0 +1,59 @@
+(ns refactor-nrepl.ns.resolve-missing-caching-test
+  (:require [clojure
+             [edn :as edn]]
+            [clojure.tools.nrepl :as nrepl]
+            [refactor-nrepl.ns.resolve-missing-test :refer [session-fixture]]
+            [clojure.test :refer [deftest testing is use-fixtures]]
+            [clojure.string :as str]))
+
+(use-fixtures :each session-fixture)
+
+(defn message [arg-map]
+  (let [{:keys [error] :as response}
+        (refactor-nrepl.ns.resolve-missing-test/message arg-map)]
+    (when error
+      (throw (RuntimeException. error)))
+    response))
+
+(defn nrepl-intern-var [ns name]
+  (message {:op :eval
+            :ns ns
+            :code (nrepl/code* `(defn ~name [] :sentinel))}))
+
+(defn nrepl-deftype [ns name]
+  (message {:op :eval
+            :ns ns
+            :code (nrepl/code* `(deftype ~name [~'a-field]))}))
+
+(defn nrepl-resolve-missing [sym]
+  (message {:op :resolve-missing :symbol sym}))
+
+(deftest caching-test
+  (testing "Finds newly defined symbols"
+    (let [this-ns 'refactor-nrepl.ns.resolve-missing-caching-test
+          varname (gensym 'new-function-)]
+
+      (nrepl-resolve-missing varname)    ;; fill cache
+      (nrepl-intern-var this-ns varname) ;; intern new var
+
+      (let [response (nrepl-resolve-missing varname)]
+        (is (seq (:candidates response)))
+
+        (let [{:keys [name type]} (first (edn/read-string (:candidates response)))]
+          (is (= :sentinel ((ns-resolve this-ns varname))))
+          (is (= this-ns name))
+          (is (= :ns type))))))
+
+  (testing "Finds newly defined classes"
+    (let [this-ns 'refactor-nrepl.ns.resolve-missing-caching-test
+          varname (gensym 'NewType)]
+
+      (nrepl-resolve-missing varname) ;; fill cache
+      (nrepl-deftype this-ns varname) ;; intern new var
+
+      (let [response (nrepl-resolve-missing varname)]
+        (is (seq (:candidates response)))
+
+        (let [{:keys [name type]} (first (edn/read-string (:candidates response)))]
+          (is (= (symbol (str/replace (str this-ns "." varname) #"-" "_")) name))
+          (is (= :type type)))))))


### PR DESCRIPTION
resolve-missing internally caches a symbol->namespace mapping. New vars that
were added later are not in the cache, and so can not be found.

This code maintains a list of namespaces that were manipulated through nREPL,
and will recheck these every time, incrementally adding to the cache.

Currently this list of dirty namespaces is append only. It will grow over time,
but should still remain small compared to the whole of all loaded namespaces.

This represents a half way point. This same tracking can be extended for other
cached functions in slam.hound.regrow, such as for imports. When that happens
removing namespaces from the dirty list can only be done when all caches have
been updated or invalidated.

Closes #160 

This is my first PR here, it took some searching around. I'd appreciate any feedback.