### PR TITLE
Fix a NullPointerException in nrepl-refactor.core/prefix

### DIFF
--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -206,8 +206,9 @@
   clojure.walk/walk -> clojure.walk
   :clojure.core/kw -> kw"
   [fully-qualified-name]
-  (if(re-find #"/" (str fully-qualified-name))
-    (-> fully-qualified-name str (.split "/") first (str/replace #"^:" ""))
+  (if (re-find #"/" (str fully-qualified-name))
+    (when-let [ns-name (-> fully-qualified-name str (.split "/") first)]
+      (str/replace ns-name #"^:" ""))
     (let [parts (-> fully-qualified-name str (.split "\\.") butlast)]
       (when (seq parts)
         (str/join "." parts)))))


### PR DESCRIPTION
When a file contains the symbol `'/` (e.g. `(/ 6 2)`), then `symbols-in-file`
through `fix-ns-of-backquoted-symbols` will try to find the prefix of that
symbol. The prefix function thinks the slash is a namespace separator, and
things blow up.

This seems to have been introduced in

3839db7 Fix clean-ns with namespaced keywords

Before `(prefix '/)` would simply return `nil`, this fix restores the old behavior.