### PR TITLE
Remove laziness in Slamhound's "get-available-classes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs fixed
 
-*
+* [#184](https://github.com/clojure-emacs/refactor-nrepl/pull/184) In `resolve-missing`, prevent classpaths with many entries from causing a stack overflow.
 * [clojure-emacs/clj-refactor.el#330](https://github.com/clojure-emacs/clj-refactor.el/issues/332) `clean-ns` removes imported inner inner classes.
 * [clojure-emacs/clj-refactor.el#330](https://github.com/clojure-emacs/clj-refactor.el/issues/330) `clean-ns` ignores namespaced keywords.
 * [#160](https://github.com/clojure-emacs/refactor-nrepl/issues/160) Make `resolve-missing` find newly defined vars and types (clj). Because of a stale cache, newly added vars or types would not be found. This fix takes into account vars/types added by eval-ing code (rescan affected namespace), and by hotloading dependencies (reset the cache).


### PR DESCRIPTION
Once the classpath gets big enough, this would cause a stack overflow, which
from clj-refactor simply shows up as a timeout.

Instead use transducers over lists as much as possible. Since the collection of
available classes is only ever traversed sequentially, this provides the best
performance as well.


- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s) --> functionality hasn't changed, so no tests added
- [x] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality) --> no user visible changes
- [x] You've updated the readme (if adding/changing user-visible functionality) --> no user visible changes

Thanks!
