### PR TITLE
Report problems of type java.lang.Error back to the nREPL client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 *
+* [#185](https://github.com/clojure-emacs/refactor-nrepl/issues/185) Report throwables of type `Error` instead of swallowing them.
 * [clojure-emacs/clj-refactor.el#330](https://github.com/clojure-emacs/clj-refactor.el/issues/332) `clean-ns` removes imported inner inner classes.
 * [clojure-emacs/clj-refactor.el#330](https://github.com/clojure-emacs/clj-refactor.el/issues/330) `clean-ns` ignores namespaced keywords.
 * [#160](https://github.com/clojure-emacs/refactor-nrepl/issues/160) Make `resolve-missing` find newly defined vars and types (clj). Because of a stale cache, newly added vars or types would not be found. This fix takes into account vars/types added by eval-ing code (rescan affected namespace), and by hotloading dependencies (reset the cache).

--- a/src/refactor_nrepl/middleware.clj
+++ b/src/refactor_nrepl/middleware.clj
@@ -37,6 +37,9 @@
         ~transport (response-for ~msg :error (.getMessage e#) :status :done)))
      (catch Exception e#
        (transport/send
+        ~transport (response-for ~msg (err-info e# :refactor-nrepl-error))))
+     (catch Error e#
+       (transport/send
         ~transport (response-for ~msg (err-info e# :refactor-nrepl-error))))))
 
 (defmacro ^:private reply [transport msg & kvs]


### PR DESCRIPTION
Error inherits directly from Throwable, so Errors are not Exceptions, they need
to be handled separately. This category includes RuntimeError,
StackOverflowError, and NoClassDefFoundError.

In regular applications you would not catch these, but in our case letting them
bubble means the nREPL handler dies without returning a response, causing the
client to assume that the operation is taking too long and time out, without any
useful feedback.

This is bad UX, and it makes it hard to diagnose and debug problems like #184.
At least this way the user will see a stack trace that hints at the problem.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)

Thanks!
