### PR TITLE
Handle NoClassDefFoundError when determining class type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 *
+* [#186](https://github.com/clojure-emacs/refactor-nrepl/issues/186) Make sure `resolve-missing` still works, even if a candidate class has missing dependencies.
 * [clojure-emacs/clj-refactor.el#330](https://github.com/clojure-emacs/clj-refactor.el/issues/332) `clean-ns` removes imported inner inner classes.
 * [clojure-emacs/clj-refactor.el#330](https://github.com/clojure-emacs/clj-refactor.el/issues/330) `clean-ns` ignores namespaced keywords.
 * [#160](https://github.com/clojure-emacs/refactor-nrepl/issues/160) Make `resolve-missing` find newly defined vars and types (clj). Because of a stale cache, newly added vars or types would not be found. This fix takes into account vars/types added by eval-ing code (rescan affected namespace), and by hotloading dependencies (reset the cache).

--- a/src/refactor_nrepl/ns/resolve_missing.clj
+++ b/src/refactor_nrepl/ns/resolve_missing.clj
@@ -25,7 +25,16 @@
 
 (defn- collate-type-info
   [candidates]
-  (map (fn [candidate] {:name candidate :type (get-type candidate)}) candidates))
+  (map (fn [candidate]
+         (try
+           {:name candidate :type (get-type candidate)}
+
+           ;; This happends when class `candidate` depends on a class that is
+           ;; not available on the classpath.
+           (catch NoClassDefFoundError e
+             {:name candidate :type :class})))
+       candidates))
+
 
 (defn- inlined-dependency? [candidate]
   (or (-> candidate str (.startsWith "deps."))


### PR DESCRIPTION
When `resolve-missing` gets a number of candidate classes, it will load them to
determine the type (Clojure type/record vs regular Java class). However a class
on the classpath may be compiled with dependencies that are not currently
present, causing the loading to fail.

This would cause the whole operation to fail, instead this change handles the
exception, takes it as a sign that it's a regular Java class, and continues.

For example, I do a `resolve-missing` on the symbol URL, this yields two
candidates: `java.net.URL`, and
`com.gargoylesoftware.htmlunit.javascript.host.URL`. The latter depends on
`org.w3c.dom.ElementTraversal`, which is not currently present, causing a
`NoClassDefFoundError`.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)

Thanks!
