### PR TITLE
Upgrade clojure.tools.reader to support namespaced map literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* [#187](https://github.com/clojure-emacs/refactor-nrepl/issues/187) Update clojure.tools.reader so Clojure 1.9 namespaced map literals don't cause parse errors.
 * [#185](https://github.com/clojure-emacs/refactor-nrepl/issues/185) Report throwables of type `Error` instead of swallowing them.
 * [#186](https://github.com/clojure-emacs/refactor-nrepl/issues/186) Make sure `resolve-missing` still works, even if a candidate class has missing dependencies.
 * [#184](https://github.com/clojure-emacs/refactor-nrepl/pull/184) In `resolve-missing`, prevent classpaths with many entries from causing a stack overflow.

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  ^:source-dep [alembic "0.3.2"]
                  ^:source-dep [org.clojure/tools.analyzer.jvm "0.6.9"]
                  ^:source-dep [org.clojure/tools.namespace  "0.3.0-alpha3"]
-                 ^:source-dep [org.clojure/tools.reader "0.10.0-alpha3"]
+                 ^:source-dep [org.clojure/tools.reader "1.0.0-beta4"]
                  ^:source-dep [org.clojure/java.classpath "0.2.2"]
                  ^:source-dep [lein-cljfmt "0.3.0"]
                  ^:source-dep [me.raynes/fs "1.4.6"]


### PR DESCRIPTION
And one more :)

`clean-ns` was failing on namespaces that contain Clojure 1.9 style namespaced maps. Because the included version of tools reader was pretty far out of date. This bumps the version from 0.10.0-alpha3 to 1.0.0-beta4. Namespaced maps are supported since tools.reader 1.0.0-beta3.

Is there a general policy on when to bump dependencies? There are quite a few that could be updated. Also, would it make sense to add a `:1.9` profile to test for Clojure 1.9 compatibility?

- [x] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)

Thanks!
