### PR TITLE
Add a profile to test for Clojure 1.9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
   - ./latest-lein source-deps :prefix-exclusions "[\"classlojure\"]"
   - ./latest-lein with-profile +plugin.mranderson/config test
   - ./latest-lein with-profile +1.8,+plugin.mranderson/config test
+  - ./latest-lein with-profile +1.9,+plugin.mranderson/config test
 jdk:
   - openjdk7
   - oraclejdk7

--- a/project.clj
+++ b/project.clj
@@ -23,6 +23,8 @@
              :test {:dependencies [[print-foo "1.0.1"]]
                     :src-paths ["test/resources"]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha14"]
+                                  [org.clojure/clojurescript "1.9.293"]]}
              :dev {:plugins [[jonase/eastwood "0.2.0"]]
                    :dependencies [[org.clojure/clojurescript "1.7.48"]
                                   [com.cemerick/piggieback "0.2.1"]


### PR DESCRIPTION
Ok, last one (for now) :) I really need to get to work on some other stuff :D

I ran the tests for 1.9, had to add a newer ClojureScript to the profile as well since the version used contained an invalid `ns` form which tripped up the new specs for built-in macros.

I'll wait for Travis to finish the testing for 1.7 and 1.9
