### PR TITLE
clean-ns: Introduce ^:keep metadata on libspecs

### DIFF
--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -245,12 +245,16 @@
   metadata which shouldn't be printed back out."
   [file-content]
   (let [ns-string (sexp/get-first-sexp file-content)
-        meta? (-> ns-string (.replaceFirst "\\^\\{" "\\{")
-                  (StringReader.)
-                  (PushbackReader.)
-                  parse/read-ns-decl
-                  second)
-        shorthand-meta?  (second (re-find #"\^:([^\s]+)\s" ns-string))]
+        ns-decl (-> ns-string
+                    (.replaceFirst "\\^\\{" "\\{")
+                    (StringReader.)
+                    (PushbackReader.)
+                    parse/read-ns-decl)
+        meta? (second ns-decl)
+        ns-name (if (symbol? meta?) meta? (first (nnext ns-decl)))
+        shorthand-meta? (-> (java.util.regex.Pattern/compile (str "\\^:([^\\s]+)\\s" ns-name))
+                            (re-find ns-string)
+                            second)]
     (cond
       (map? meta?) meta?
       shorthand-meta? {::shorthand-meta (keyword shorthand-meta?)}

--- a/src/refactor_nrepl/ns/ns_parser.clj
+++ b/src/refactor_nrepl/ns/ns_parser.clj
@@ -19,10 +19,11 @@
 
 (defn- libspec-vector->map
   [libspec]
-  (if (vector? libspec)
-    (let [[ns & specs] libspec]
-      (into {:ns ns} (->> specs (partition 2) (map vec))))
-    {:ns (symbol libspec)}))
+  (-> (if (vector? libspec)
+          (let [[ns & specs] libspec]
+            (into {:ns ns} (->> specs (partition 2) (map vec))))
+        {:ns (symbol libspec)})
+      (with-meta (meta libspec))))
 
 (defn- expand-prefix-specs
   "Eliminate prefix lists."

--- a/src/refactor_nrepl/ns/pprint.clj
+++ b/src/refactor_nrepl/ns/pprint.clj
@@ -32,6 +32,19 @@
                             (printf "%s " libspec))))))
                   ordered-libspecs))))
 
+(defn pprint-meta
+  [m]
+  (if-let [shorthand-meta (::core/shorthand-meta m)]
+    (print (str "^" shorthand-meta " "))
+    (printf (.replaceAll (str "^" (into (sorted-map) m) "\n")
+                         ", " "\n"))))
+
+(defn- pprint-libspec [libspec]
+  (when (seq (meta libspec)) (pprint-meta (meta libspec)))
+  (if (prefix-form? libspec)
+    (pprint-prefix-form libspec)
+    (pprint libspec)))
+
 (defn pprint-require-form
   [[_ & libspecs]]
   (print "(:require ")
@@ -40,12 +53,8 @@
     (fn [idx libspec]
       (if (= idx (dec (count libspecs)))
         (printf "%s)\n" (str/trim-newline
-                         (with-out-str (if (prefix-form? libspec)
-                                         (pprint-prefix-form libspec)
-                                         (pprint libspec)))))
-        (if (prefix-form? libspec)
-          (pprint-prefix-form libspec)
-          (pprint libspec))))
+                         (with-out-str (pprint-libspec libspec))))
+        (pprint-libspec libspec)))
     libspecs)))
 
 (defn- form-is? [form type]
@@ -75,13 +84,6 @@
         (printf "%s)\n" import)
         (println import)))
     imports)))
-
-(defn pprint-meta
-  [m]
-  (if-let [shorthand-meta (::core/shorthand-meta m)]
-    (print (str "^" shorthand-meta " "))
-    (printf (.replaceAll (str "^" (into (sorted-map) m) "\n")
-                         ", " "\n"))))
 
 (defn pprint-ns
   [[_ name & more :as ns-form]]

--- a/src/refactor_nrepl/ns/prune_dependencies.clj
+++ b/src/refactor_nrepl/ns/prune_dependencies.clj
@@ -67,13 +67,15 @@
 
 (defn- remove-unused-syms-and-specs
   [used-syms current-ns libspec]
-  (some-> libspec
-          (libspec-in-use? used-syms current-ns)
-          (prune-key :refer used-syms)
-          (prune-key :refer-macros used-syms)
-          (util/dissoc-when (fn empty-and-not-kw [k]
-                              (and (not (keyword k)) (empty? k)))
-                            :refer :refer-macros)))
+  (if (:keep (meta libspec))
+    libspec
+    (some-> libspec
+            (libspec-in-use? used-syms current-ns)
+            (prune-key :refer used-syms)
+            (prune-key :refer-macros used-syms)
+            (util/dissoc-when (fn empty-and-not-kw [k]
+                                (and (not (keyword k)) (empty? k)))
+                              :refer :refer-macros))))
 
 (defn- static-method-or-field-access->Classname
   [symbol-in-file]

--- a/src/refactor_nrepl/ns/rebuild.clj
+++ b/src/refactor_nrepl/ns/rebuild.clj
@@ -119,20 +119,22 @@
   [{:keys [ns as refer rename refer-macros] :as libspec}]
   (let [all-flags #{:reload :reload-all :verbose :include-macros}
         flags (util/filter-map #(all-flags (first %)) libspec)]
-    (if (and (not as) (not refer)
-             (empty? flags) (empty? rename) (empty? refer-macros))
-      ns
-      (into [ns]
-            (concat (when as [:as as])
-                    (when refer
-                      [:refer (if (sequential? refer)
-                                (vec (sort-referred-symbols refer))
-                                refer)])
-                    (when refer-macros
-                      [:refer-macros (vec (sort-referred-symbols refer-macros))])
-                    (when (not-empty rename)
-                      [:rename (into (sorted-map) (:rename libspec))])
-                    (flatten (seq flags)))))))
+    (cond->
+        (if (and (not as) (not refer)
+                 (empty? flags) (empty? rename) (empty? refer-macros))
+          ns
+          (into [ns]
+                (concat (when as [:as as])
+                        (when refer
+                          [:refer (if (sequential? refer)
+                                    (vec (sort-referred-symbols refer))
+                                    refer)])
+                        (when refer-macros
+                          [:refer-macros (vec (sort-referred-symbols refer-macros))])
+                        (when (not-empty rename)
+                          [:rename (into (sorted-map) (:rename libspec))])
+                        (flatten (seq flags)))))
+      (-> libspec meta :keep) (with-meta {:refactor-nrepl.core/shorthand-meta :keep}))))
 
 (defn- create-libspec-vectors-without-prefix
   [libspecs]

--- a/test/refactor_nrepl/ns/clean_ns_test.clj
+++ b/test/refactor_nrepl/ns/clean_ns_test.clj
@@ -39,6 +39,9 @@
 
 (def ns-with-shorthand-meta (clean-msg "test/resources/ns_with_shorthand_meta.clj"))
 
+(def ns-with-keep-metadata (clean-msg "test/resources/ns_with_keep_metadata.clj"))
+(def ns-with-keep-metadata-rebuilt (core/read-ns-form-with-meta (absolute-path "test/resources/ns_with_keep_metadata_rebuilt.clj")))
+
 (deftest combines-requires
   (let [requires (core/get-ns-component (clean-ns ns2) :require)
         combined-requires (core/get-ns-component ns2-cleaned :require)]
@@ -192,3 +195,8 @@
 (deftest preserves-shorthand-meta
   (let [cleaned (pprint-ns (clean-ns ns-with-shorthand-meta))]
     (is (re-find #"\^:automation" cleaned))))
+
+(deftest respects-keep-metadata
+  (let [new-require (core/get-ns-component (clean-ns ns-with-keep-metadata) :require)
+        expected-require (core/get-ns-component ns-with-keep-metadata-rebuilt :require)]
+    (is (= expected-require new-require))))

--- a/test/resources/ns_with_keep_metadata.clj
+++ b/test/resources/ns_with_keep_metadata.clj
@@ -1,0 +1,3 @@
+(ns resources.ns-with-keep-metadata
+  (:require [clojure.set]
+            ^:keep [clojure.string]))

--- a/test/resources/ns_with_keep_metadata_rebuilt.clj
+++ b/test/resources/ns_with_keep_metadata_rebuilt.clj
@@ -1,0 +1,2 @@
+(ns resources.ns-with-keep-metadata-rebuilt
+  (:require ^:keep clojure.string))


### PR DESCRIPTION
This allows marking up required namespaces that should not be cleaned by clean-ns.

This is useful to require namespaces only so they get loaded for side-effects. It can also be used in `(ns user)` to make functions available for the REPL.

Example

``` clojure
    (ns user
      (:require [com.stuartsierra.component :as component]
                ^:keep [reloaded.repl :refer [system init start stop go reset]]])
```

This PR is not ready yet, I'm just at the point where I got it to work, and I'd appreciate feedback.

Questions:

- Is `^:keep` the best key to use? (bikeshedding time!)
- Right now it's only supported in `:require`, does it make sense to also have it for `:import` or `:use`. (Probably not since you don't usually `:import` for side effects, and `:use` is deprecated, but maybe there's an argument to be made).
- Should it also work on individuals function names in a `:refer` macro?
- Should it work on nested vectors when grouping by prefix?

Todo for me:

- [ ] Check if it also works on CLJS/CLJC
- [ ] Update CHANGELOG
- [ ] Update README


----

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (run `lein do clean, test`)
- [ ] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
