### PR TITLE
Fix reflection warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
                  ^:source-dep [rewrite-clj "0.4.13-SNAPSHOT"]
                  ^:source-dep [cljs-tooling "0.1.7"]
                  ^:source-dep [version-clj "0.1.2"]]
+  :global-vars {*warn-on-reflection* true}
   :plugins [[thomasa/mranderson "0.4.7"]]
   :filespecs [{:type :bytes :path "refactor-nrepl/refactor-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
   :profiles {:provided {:dependencies [[cider/cider-nrepl "0.10.0"]

--- a/src/refactor_nrepl/analyzer.clj
+++ b/src/refactor_nrepl/analyzer.clj
@@ -107,7 +107,7 @@
       (throw ast-or-err)
 
       error?
-      (throw-ast-in-bad-state file-content (.getMessage ast-or-err))
+      (throw-ast-in-bad-state file-content (.getMessage ^Throwable ast-or-err))
 
       :default
       ast-or-err)))
@@ -118,7 +118,7 @@
                 (->> (vals asts)
                      (mapcat vals)
                      (map #(if (instance? Throwable %)
-                             (list "error" (.getMessage %))
+                             (list "error" (.getMessage ^Throwable %))
                              "OK"))))))
 
 (defn warm-ast-cache []
@@ -128,8 +128,8 @@
       (catch Throwable th))) ;noop, ast-status will be reported separately
   (ast-stats))
 
-(defn node-at-loc? [loc-line loc-column node]
-  (let [{:keys [line end-line column end-column]} (:env node)]
+(defn node-at-loc? [^long loc-line ^long loc-column node]
+  (let [{:keys [^long line ^long end-line ^long column ^long end-column]} (:env node)]
     ;; The node for ::an-ns-alias/foo, when it appeared as a toplevel form,
     ;; had nil as position info
     (and line end-line column end-column

--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -7,7 +7,7 @@
             [me.raynes.fs :as fs]
             [refactor-nrepl.util :refer [normalize-to-unix-path]]
             [refactor-nrepl.s-expressions :as sexp])
-  (:import [java.io FileReader PushbackReader StringReader]))
+  (:import [java.io File FileReader PushbackReader StringReader]))
 
 (defn version []
   (let [v (-> (or (io/resource "refactor-nrepl/refactor-nrepl/project.clj")
@@ -45,18 +45,18 @@
   to use as a starting point. We search anything above this dir, until
   we reach the file system root. Default value is the property
   `user.dir`."
-  ([] (project-root (System/getProperty "user.dir")))
-  ([path-or-file-in-project]
+  (^File [] (project-root (System/getProperty "user.dir")))
+  (^File [path-or-file-in-project]
    (let [path-or-file-in-project (io/file path-or-file-in-project)
          start (if (fs/directory? path-or-file-in-project)
                  path-or-file-in-project
                  (fs/parent path-or-file-in-project))
          names-at-root #{"project.clj" "build.boot" "build.gradle" "pom.xml"}
-         known-root-file? (fn [f] (some (fn [known-root-name]
-                                          (.endsWith (.getCanonicalPath f)
-                                                     known-root-name))
-                                        names-at-root))
-         root-dir? (fn [f] (some known-root-file? (.listFiles f)))
+         known-root-file? (fn [^File f] (some (fn [known-root-name]
+                                                (.endsWith (.getCanonicalPath f)
+                                                           known-root-name))
+                                              names-at-root))
+         root-dir? (fn [^File f] (some known-root-file? (.listFiles f)))
          most-likely-root (io/file (System/getProperty "user.dir"))]
      (if (root-dir? most-likely-root)
        most-likely-root
@@ -72,7 +72,7 @@
                         normalize-to-unix-path
                         (str "/target"))
         parent-paths (map (comp normalize-to-unix-path
-                                (memfn getCanonicalPath))
+                                (memfn ^File getCanonicalPath))
                           (fs/parents f))]
     (and (some #{target-path} parent-paths)
          path-or-file)))
@@ -192,7 +192,7 @@
 (defn strip-reader-macros
   "Strip reader macros like #' and . (as in '(Date.)') from
   symbol-or-string."
-  [symbol-or-string]
+  ^String [symbol-or-string]
   (let [s (-> symbol-or-string
               str
               (str/replace "#'" ""))]

--- a/src/refactor_nrepl/extract_definition.clj
+++ b/src/refactor_nrepl/extract_definition.clj
@@ -13,7 +13,7 @@
   (zipmap (take-nth 2 occurrence) (take-nth 2 (rest occurrence))))
 
 (defn- extract-definition-from-def
-  [^String sexp]
+  ^String [^String sexp]
   (let [def-form (read-string sexp)
         docstring? (string? (nth def-form 2 :not-found))
         sexp-sans-delimiters (.substring (str/trim sexp) 1 (dec (.length sexp)))
@@ -25,7 +25,7 @@
     (str/trim (slurp rdr))))
 
 (defn- extract-definition-from-defn
-  [^String sexp]
+  ^String [^String sexp]
   (let [form (read-string sexp)
         fn-name (str (second form))]
     (-> sexp
@@ -33,7 +33,7 @@
         (.replaceFirst (str "\\s*" (Pattern/quote fn-name)) ""))))
 
 (defn- extract-def-from-binding-vector
-  [^String bindings ^String var-name]
+  ^String [^String bindings ^String var-name]
   (let [zipper (zip/of-string bindings)
         zloc (some (fn [zloc] (when (= (symbol var-name) (zip/sexpr zloc)) zloc))
                    (sexp/all-zlocs zipper))]
@@ -41,7 +41,7 @@
       (str/trim (zip/string (zip/right zloc))))))
 
 (defn- -extract-definition
-  [{:keys [match file line-beg col-beg name]}]
+  [{:keys [match file ^long line-beg ^long col-beg name]}]
   (let [literal-sexp (sexp/get-enclosing-sexp (slurp file) (dec line-beg)
                                               col-beg)
         form (read-string literal-sexp)]
@@ -67,7 +67,7 @@
 
 (defn- def?
   "Is the OCCURRENCE the defining form?"
-  [{:keys [file name col-beg line-beg] :as occurrence}]
+  [{:keys [file name ^long col-beg ^long line-beg] :as occurrence}]
   (let [form (read-string (sexp/get-enclosing-sexp (slurp file) (dec line-beg)
                                                    col-beg))
         name (symbol (suffix (read-string name)))]
@@ -78,7 +78,7 @@
 
 (defn- sort-by-linum
   [occurrences]
-  (sort #(- (:line-beg %1) (:line-beg %2)) occurrences))
+  (sort #(- (long (:line-beg %1)) (long (:line-beg %2))) occurrences))
 
 (defn- find-definition [occurrences]
   (some->> occurrences

--- a/src/refactor_nrepl/find/find_locals.clj
+++ b/src/refactor_nrepl/find/find_locals.clj
@@ -6,7 +6,7 @@
              [s-expressions :as sexp]
              [core :as core]]))
 
-(defn find-used-locals  [{:keys [file line column]}]
+(defn find-used-locals  [{:keys [file ^long line ^long column]}]
   {:pre [(number? line)
          (number? column)
          (not-empty file)]}

--- a/src/refactor_nrepl/find/util.clj
+++ b/src/refactor_nrepl/find/util.clj
@@ -4,7 +4,7 @@
 
 (defn spurious?
   "True if the occurrence doesn't exist at the given coordinates."
-  ([{:keys [file line-beg col-beg col-end name match] :as occ}]
+  ([{:keys [file ^long line-beg ^long col-beg ^long col-end name ^String match] :as occ}]
    ;; coordinates are wrong for def forms, they match the beginning of
    ;; the form not the first mention of the symbol being defined
    (when-not (and match (.startsWith match "(def"))

--- a/src/refactor_nrepl/ns/libspecs.clj
+++ b/src/refactor_nrepl/ns/libspecs.clj
@@ -1,6 +1,7 @@
 (ns refactor-nrepl.ns.libspecs
   (:require [refactor-nrepl.core :as core]
-            [refactor-nrepl.ns.ns-parser :as ns-parser]))
+            [refactor-nrepl.ns.ns-parser :as ns-parser])
+  (:import [java.io File]))
 
 ;; The structure here is {path {lang [timestamp value]}}
 ;; where lang is either :clj or :cljs
@@ -24,12 +25,12 @@
        (mapcat identity)
        (apply hash-map)))
 
-(defn- get-cached-libspec [f lang]
+(defn- get-cached-libspec [^File f lang]
   (when-let [[ts v] (get-in @cache [(.getAbsolutePath f) lang])]
     (when (= ts (.lastModified f))
       v)))
 
-(defn- put-cached-libspec [f lang]
+(defn- put-cached-libspec [^File f lang]
   (let [libspecs (ns-parser/get-libspecs-from-file lang f)]
     (swap! cache assoc-in [(.getAbsolutePath f) lang]
            [(.lastModified f) libspecs])

--- a/src/refactor_nrepl/ns/pprint.clj
+++ b/src/refactor_nrepl/ns/pprint.clj
@@ -15,7 +15,7 @@
   (printf "[%s" name)
   (let [ordered-libspecs (libspec-vectors-last libspecs)]
     (dorun
-     (map-indexed (fn [idx libspec]
+     (map-indexed (fn [^long idx libspec]
                     ;; insert newline after all non-libspec vectors
                     (when (and (vector? libspec)
                                (or (zero? idx)

--- a/src/refactor_nrepl/ns/prune_dependencies.clj
+++ b/src/refactor_nrepl/ns/prune_dependencies.clj
@@ -32,9 +32,9 @@
                     (concat refer require-macros refer-macros)))
           (map str (concat refer require-macros refer-macros))) symbol-in-file))
    ;; Used as a fully qualified symbol
-   (.startsWith symbol-in-file (str ns "/"))
+   (.startsWith ^String symbol-in-file (str ns "/"))
    ;; Aliased symbol in use
-   (and as (.startsWith symbol-in-file (str as "/")))))
+   (and as (.startsWith ^String symbol-in-file (str as "/")))))
 
 (defn- libspec-in-use-with-rename?
   [{:keys [rename] :as libspec} symbols-in-file]

--- a/src/refactor_nrepl/ns/rebuild.clj
+++ b/src/refactor_nrepl/ns/rebuild.clj
@@ -56,7 +56,8 @@
     (for [libspecs (vals @libspecs-by-ns)]
       (merge-libspecs libspecs))))
 
-(defn- get-sort-name [dep]
+(defn- get-sort-name
+  ^String [dep]
   (str/lower-case
    (if (sequential? dep)
      (let [name (-> dep first name)

--- a/src/refactor_nrepl/rename_file_or_dir.clj
+++ b/src/refactor_nrepl/rename_file_or_dir.clj
@@ -27,15 +27,15 @@
                            re-pattern
                            (str/split (str/lower-case path))
                            second))
-        shortest (fn [acc val] (if (< (.length acc) (.length val)) acc val))]
+        shortest (fn [^String acc ^String val] (if (< (.length acc) (.length val)) acc val))]
     (let [relative-paths (->> (core/dirs-on-classpath)
-                              (map (memfn getAbsolutePath))
+                              (map (memfn ^File getAbsolutePath))
                               (map util/normalize-to-unix-path)
                               (map chop-prefix)
                               (remove nil?))]
-      (if-let [p (cond
-                   (= (count relative-paths) 1) (first relative-paths)
-                   (> (count relative-paths) 1) (reduce shortest relative-paths))]
+      (if-let [^String p (cond
+                           (= (count relative-paths) 1) (first relative-paths)
+                           (> (count relative-paths) 1) (reduce shortest relative-paths))]
         (if (.startsWith p "/")
           (.substring p 1)
           p)
@@ -200,7 +200,7 @@
         tracker (tracker/build-tracker)
         dependents (tracker/get-dependents tracker old-ns)
         new-dependents (atom {})]
-    (doseq [f dependents]
+    (doseq [^File f dependents]
       (swap! new-dependents
              assoc (.getAbsolutePath f) (update-dependent f old-ns new-ns)))
     (rename-file! old-path new-path)
@@ -219,7 +219,7 @@
         new-path (util/normalize-to-unix-path new-path)
         old-path (if (.endsWith old-path "/") old-path (str old-path "/"))
         new-path (if (.endsWith new-path "/") new-path (str new-path "/"))]
-    (flatten (for [f (file-seq (File. old-path))
+    (flatten (for [^File f (file-seq (File. old-path))
                    :when (not (fs/directory? f))
                    :let [path (util/normalize-to-unix-path (.getAbsolutePath f))]]
                (-rename-file-or-dir path (merge-paths path old-path new-path))))))

--- a/src/refactor_nrepl/s_expressions.clj
+++ b/src/refactor_nrepl/s_expressions.clj
@@ -13,7 +13,8 @@
       (not (zip/sexpr zloc)) ; comment node
       (string? (zip/sexpr zloc))))
 
-(defn get-first-sexp [file-content]
+(defn get-first-sexp
+  ^String [file-content]
   (let [reader (zip-reader/string-reader file-content)]
     (loop [sexp (zip-parser/parse reader)]
       (let [zloc (zip/edn sexp)]
@@ -22,7 +23,8 @@
           (when (.peek-char reader)
             (recur (zip-parser/parse reader))))))))
 
-(defn get-last-sexp [file-content]
+(defn get-last-sexp
+  ^String [file-content]
   (let [zloc (->> file-content zip/of-string zip/rightmost)]
     (some (fn [zloc] (when-not (comment-or-string-or-nil? zloc)
                        (zip/string zloc)))
@@ -30,18 +32,18 @@
 
 (defn- zip-to
   "Move the zipper to the node at line and col"
-  [zipper line col]
+  [zipper ^long line ^long col]
   (let [distance (fn [zloc]
                    (let [node (zip/node zloc)
-                         line-beg (dec (:row (meta node)))
-                         line-end (dec (:end-row (meta node)))
-                         col-beg (dec (:col (meta node)))
-                         col-end (dec (:end-col (meta node)))]
+                         line-beg (dec (long (:row (meta node))))
+                         line-end (dec (long (:end-row (meta node))))
+                         col-beg (dec (long (:col (meta node))))
+                         col-end (dec (long (:end-col (meta node))))]
                      (+ (* 1000 (Math/abs (- line line-beg)))
                         (* 100 (Math/abs (- line line-end)))
                         (* 10 (Math/abs (- col col-beg)))
                         (Math/abs (- col col-end)))))]
-    (reduce (fn [best zloc] (if (< (distance zloc) (distance best))
+    (reduce (fn [best zloc] (if (< (long (distance zloc)) (long (distance best)))
                               zloc
                               best))
             zipper
@@ -58,7 +60,7 @@
   Both line and column are indexed from 0."
   ([file-content line column]
    (get-enclosing-sexp file-content line column 1))
-  ([file-content line column level]
+  ([file-content ^long line ^long column ^long level]
    (let [zloc (zip-to (zip/of-string file-content) line column)
          zloc (nth (iterate zip/up zloc) (dec level))]
      (cond

--- a/src/refactor_nrepl/util.clj
+++ b/src/refactor_nrepl/util.clj
@@ -3,7 +3,7 @@
 
 (defn normalize-to-unix-path
   "Replace use / as separator and lower-case."
-  [path]
+  ^String [^String path]
   (if (.contains (System/getProperty "os.name") "Windows")
     (.replaceAll path (Pattern/quote "\\") "/")
     path))


### PR DESCRIPTION
This PR is a very low-hanging fruit as far as performance optimizations go. It simply adds type hints to fix all the reflection warnings I could find in the `src/` tree, with only a few exceptions where a file path can be either a `String` or a `java.util.File`. Maybe the `fs` library could be used more liberally for that?

I've also added `*warn-on-reflection*` in project.clj to avoid these in the future.

Unfortunately I do not have any benchmarks to showcase performance improvements. However this branch does allow me to run commands such as `cljr-rename-symbol` on a large project whereas master consistently times out :man_shrugging:  