### PR TITLE
Add config for ignoring specific paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### New features
 
 * New config setting `:libspec-whitelist` which makes it possible to create a seq of namespaces `clean-ns` shouldn't prune.  This is useful for libspecs which aren't used except through side-effecting loads.
+* New config setting `:ignore-paths` for ignoring certain paths when finding dirs on classpath.
 
 ## 2.2.0
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ Configuration settings are passed along with each msg, currently the recognized 
  ;; This seq of strings will be used as regexp patterns to match
  ;; against the libspec name.
  :libspec-whitelist ["^cljsjs"]
+
+ ;; Regexes matching paths that are to be ignored
+ :ignore-paths []
 }
 ```
 

--- a/src/refactor_nrepl/config.clj
+++ b/src/refactor_nrepl/config.clj
@@ -21,6 +21,9 @@
    ;; This seq of strings will be used as regexp patterns to match
    ;; against the libspec name.
    :libspec-whitelist ["^cljsjs"]
+
+   ;; Regexes matching paths that are to be ignored
+   :ignore-paths []
    })
 
 (defn opts-from-msg [msg]

--- a/test/refactor_nrepl/core_test.clj
+++ b/test/refactor_nrepl/core_test.clj
@@ -1,0 +1,28 @@
+(ns refactor-nrepl.core-test
+  (:require [clojure.test :refer :all]
+            [refactor-nrepl.config :as config]
+            [refactor-nrepl.core :refer [ignore-dir-on-classpath?]]))
+
+
+(defmacro assert-ignored-paths
+  [paths pred]
+  `(doseq [p# ~paths]
+     (is (~pred (ignore-dir-on-classpath? p#)))))
+
+
+(deftest test-ignore-dir-on-classpath?
+  (let [not-ignored ["/home/user/project/test"
+                     "/home/user/project/src"
+                     "/home/user/project/target/classes"]
+        sometimes-ignored ["/home/user/project/checkouts/subproject"
+                           "/home/user/project/resources"]
+        always-ignored ["/home/user/project/target/srcdeps"]]
+    (testing "predicate to ignore dirs on classpath with default config"
+      (assert-ignored-paths (concat not-ignored sometimes-ignored) false?)
+      (assert-ignored-paths always-ignored true?))
+    (testing "predicate to ignore dirs on classpath with custom config"
+      (binding [config/*config* (assoc config/*config*
+                                       :ignore-paths
+                                       [#".+checkouts/.+" #"resources"])]
+        (assert-ignored-paths not-ignored false?)
+        (assert-ignored-paths (concat always-ignored sometimes-ignored) true?)))))


### PR DESCRIPTION
This change will allow users to configure refactor-nrepl to ignore
certain paths when finding the dirs on classpath by specifying a seq of
regexes which the paths will be matched against.

Currently refactor-nrepl considers all the .clj files that are reachable
from project root. This is a problem if the project repository includes
example .clj files, if a user has symlinked other clj projects under
'checkouts' or if there are any other files that need to be ignored.

This change is backward compatible and wouldn't affect the current
behaviour in existing installations as the default value is an empty
seq.

This PR addresses the issue #167. 
Will add tests after having the maintainers' thoughts on this approach. 

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
