### PR TITLE
delay loading of middleware to speed up startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#198](https://github.com/clojure-emacs/refactor-nrepl/issues/187) Delay middleware loading to speed up initialization.
 ## 2.3.1
 
 ### Bugs fixed


### PR DESCRIPTION
There is probably a more elegant way to delay code loading, but this is the most obvious way I could think of.

These changes drop somewhere between 3 and 5 seconds off of repl startup time for me. Tests pass, but I only did a test of a couple features in emacs by hand. I don't actually use refactor-nrepl very much, so I'm not particularly familiar with how people use it.

clojure-emacs/cider#1717

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
