### PR TITLE
Upgraded rewrite-clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,8 +23,8 @@
              :test {:dependencies [[print-foo "1.0.2"]]
                     :src-paths ["test/resources"]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha14"]
-                                  [org.clojure/clojurescript "1.9.660"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha17"]
+                                  [org.clojure/clojurescript "1.9.671"]]}
              :dev {:plugins [[jonase/eastwood "0.2.0"]]
                    :global-vars {*warn-on-reflection* true}
                    :dependencies [[org.clojure/clojurescript "1.7.48"]

--- a/project.clj
+++ b/project.clj
@@ -35,4 +35,5 @@
                    :java-source-paths ["test/java"]
                    :resource-paths ["test/resources"
                                     "test/resources/testproject/src"]
-                   :repositories [["snapshots" "http://oss.sonatype.org/content/repositories/snapshots"]]}})
+                   :repositories [["snapshots" "http://oss.sonatype.org/content/repositories/snapshots"]]}}
+  :jvm-opts ["-Djava.net.preferIPv4Stack=true"])

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  ^:source-dep [alembic "0.3.2"]
                  ^:source-dep [org.clojure/tools.analyzer.jvm "0.7.1"]
                  ^:source-dep [org.clojure/tools.namespace  "0.3.0-alpha3"]
-                 ^:source-dep [org.clojure/tools.reader "1.0.0"]
+                 ^:source-dep [org.clojure/tools.reader "1.0.2"]
                  ^:source-dep [org.clojure/java.classpath "0.2.3"]
                  ^:source-dep [lein-cljfmt "0.3.0"]
                  ^:source-dep [me.raynes/fs "1.4.6"]

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  ^:source-dep [org.clojure/java.classpath "0.2.2"]
                  ^:source-dep [lein-cljfmt "0.3.0"]
                  ^:source-dep [me.raynes/fs "1.4.6"]
-                 ^:source-dep [rewrite-clj "0.4.13-SNAPSHOT"]
+                 ^:source-dep [rewrite-clj "0.6.0"]
                  ^:source-dep [cljs-tooling "0.1.7"]
                  ^:source-dep [version-clj "0.1.2"]]
   :plugins [[thomasa/mranderson "0.4.7"]]

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                    :dependencies [[org.clojure/clojurescript "1.9.89"]
                                   [com.cemerick/piggieback "0.2.2"]
                                   [leiningen-core "2.7.1"]
-                                  [commons-io/commons-io "2.5"]]
+                                  [commons-io/commons-io "2.6"]]
                    :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
                    :java-source-paths ["test/java"]
                    :resource-paths ["test/resources"

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                                   [org.clojure/clojurescript "1.9.671"]]}
              :dev {:plugins [[jonase/eastwood "0.2.0"]]
                    :global-vars {*warn-on-reflection* true}
-                   :dependencies [[org.clojure/clojurescript "1.7.48"]
+                   :dependencies [[org.clojure/clojurescript "1.9.89"]
                                   [com.cemerick/piggieback "0.2.2"]
                                   [leiningen-core "2.7.1"]
                                   [commons-io/commons-io "2.5"]]

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  ^:source-dep [alembic "0.3.2"]
                  ^:source-dep [org.clojure/tools.analyzer.jvm "0.7.1"]
                  ^:source-dep [org.clojure/tools.namespace  "0.3.0-alpha3"]
-                 ^:source-dep [org.clojure/tools.reader "1.0.2"]
+                 ^:source-dep [org.clojure/tools.reader "1.1.1"]
                  ^:source-dep [org.clojure/java.classpath "0.2.3"]
                  ^:source-dep [lein-cljfmt "0.3.0"]
                  ^:source-dep [me.raynes/fs "1.4.6"]

--- a/project.clj
+++ b/project.clj
@@ -3,34 +3,34 @@
   :url "http://github.com/clojure-emacs/refactor-nrepl"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/tools.nrepl "0.2.12"]
-                 ^:source-dep [http-kit "2.1.19"]
-                 ^:source-dep [cheshire "5.4.0"]
-                 ^:source-dep [clojure-emacs/alembic "0.3.3"]
-                 ^:source-dep [org.clojure/tools.analyzer.jvm "0.6.9"]
+  :dependencies [[org.clojure/tools.nrepl "0.2.13"]
+                 ^:source-dep [http-kit "2.2.0"]
+                 ^:source-dep [cheshire "5.7.1"]
+                 ^:source-dep [alembic "0.3.2"]
+                 ^:source-dep [org.clojure/tools.analyzer.jvm "0.7.1"]
                  ^:source-dep [org.clojure/tools.namespace  "0.3.0-alpha3"]
-                 ^:source-dep [org.clojure/tools.reader "1.0.0-beta4"]
-                 ^:source-dep [org.clojure/java.classpath "0.2.2"]
+                 ^:source-dep [org.clojure/tools.reader "1.0.0"]
+                 ^:source-dep [org.clojure/java.classpath "0.2.3"]
                  ^:source-dep [lein-cljfmt "0.3.0"]
                  ^:source-dep [me.raynes/fs "1.4.6"]
                  ^:source-dep [rewrite-clj "0.6.0"]
-                 ^:source-dep [cljs-tooling "0.1.7"]
+                 ^:source-dep [cljs-tooling "0.2.0"]
                  ^:source-dep [version-clj "0.1.2"]]
   :plugins [[thomasa/mranderson "0.4.7"]]
   :filespecs [{:type :bytes :path "refactor-nrepl/refactor-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
-  :profiles {:provided {:dependencies [[cider/cider-nrepl "0.10.0"]
+  :profiles {:provided {:dependencies [[cider/cider-nrepl "0.14.0"]
                                        [org.clojure/clojure "1.7.0"]]}
-             :test {:dependencies [[print-foo "1.0.1"]]
+             :test {:dependencies [[print-foo "1.0.2"]]
                     :src-paths ["test/resources"]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha14"]
-                                  [org.clojure/clojurescript "1.9.293"]]}
+                                  [org.clojure/clojurescript "1.9.660"]]}
              :dev {:plugins [[jonase/eastwood "0.2.0"]]
                    :global-vars {*warn-on-reflection* true}
                    :dependencies [[org.clojure/clojurescript "1.7.48"]
-                                  [com.cemerick/piggieback "0.2.1"]
-                                  [leiningen-core "2.5.3"]
-                                  [commons-io/commons-io "2.4"]]
+                                  [com.cemerick/piggieback "0.2.2"]
+                                  [leiningen-core "2.7.1"]
+                                  [commons-io/commons-io "2.5"]]
                    :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
                    :java-source-paths ["test/java"]
                    :resource-paths ["test/resources"

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/tools.nrepl "0.2.13"]
                  ^:source-dep [http-kit "2.2.0"]
-                 ^:source-dep [cheshire "5.7.1"]
+                 ^:source-dep [cheshire "5.8.0"]
                  ^:source-dep [alembic "0.3.2"]
                  ^:source-dep [org.clojure/tools.analyzer.jvm "0.7.1"]
                  ^:source-dep [org.clojure/tools.namespace  "0.3.0-alpha3"]

--- a/test/refactor_nrepl/integration_tests.clj
+++ b/test/refactor_nrepl/integration_tests.clj
@@ -12,6 +12,7 @@
 (defn start-up-repl-server []
   (let [server
         (nrserver/start-server
+         :bind "localhost"
          :port 7777
          :handler (nrserver/default-handler
                     #'refactor-nrepl.middleware/wrap-refactor))]

--- a/test/refactor_nrepl/ns/resolve_missing_test.clj
+++ b/test/refactor_nrepl/ns/resolve_missing_test.clj
@@ -12,7 +12,7 @@
 
 (defn session-fixture
   [f]
-  (with-open [server (server/start-server :handler *handler*)
+  (with-open [server (server/start-server :bind "localhost" :handler *handler*)
               transport (nrepl/connect :port (:port server))]
     (let [client (nrepl/client transport Long/MAX_VALUE)]
       (binding [*session* (nrepl/client-session client)]


### PR DESCRIPTION
As per Phil Hagelberg's comment in https://github.com/clojure-emacs/refactor-nrepl/issues/200

One of the dependencies for the version of rewrite-clj that this project
uses causes a non-TLS repository to be used, which is dangerous and will
not work in the next version of Leiningen.

Upgraded to the latest stable to fix the above

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)

Thanks!
