### PR TITLE
Use lein 2.6.1 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: clojure
-install:
-  - wget -c https://raw.githubusercontent.com/technomancy/leiningen/2.5.3/bin/lein -O latest-lein
-  - chmod 755 latest-lein
-  - ./latest-lein
-before_script:
-  - ./latest-lein --version
+lein: 2.6.1
 script:
-  - ./latest-lein source-deps :prefix-exclusions "[\"classlojure\"]"
-  - ./latest-lein with-profile +plugin.mranderson/config test
-  - ./latest-lein with-profile +1.8,+plugin.mranderson/config test
-  - ./latest-lein with-profile +1.9,+plugin.mranderson/config test
+  - lein2 source-deps :prefix-exclusions "[\"classlojure\"]"
+  - lein2 with-profile +plugin.mranderson/config test
+  - lein2 with-profile +1.8,+plugin.mranderson/config test
+  - lein2 with-profile +1.9,+plugin.mranderson/config test
 jdk:
   - openjdk7
   - oraclejdk7


### PR DESCRIPTION
to fix hack to use newer version of lein when only lein1 was available
on travis. no confusing exception anymore during environment setup.

follows up changes in clojure-emacs/cider-nrepl#419

 