### PR TITLE
Fix invalid stale-check

### DIFF
--- a/src/refactor_nrepl/artifacts.clj
+++ b/src/refactor_nrepl/artifacts.clj
@@ -38,7 +38,7 @@
 (defn- stale-cache? []
   (or (empty? @artifacts)
       (if-let [last-modified (some-> artifacts meta :last-modified .getTime)]
-        (neg? (- millis-per-day (- last-modified (.getTime (java.util.Date.)))))
+        (neg? (- millis-per-day (- (.getTime (java.util.Date.)) last-modified)))
         true)))
 
 (defn- get-mvn-artifacts!


### PR DESCRIPTION
The neg? check always evaluated to false because the arguments
of the time difference calculation were interchanged.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x ] All tests are passing (run `lein do clean, test`)

