### PR TITLE
Extract `err-info` from cider-nrepl

### DIFF
--- a/src/refactor_nrepl/middleware.clj
+++ b/src/refactor_nrepl/middleware.clj
@@ -1,6 +1,6 @@
 (ns refactor-nrepl.middleware
   (:require [cider.nrepl.middleware.util.cljs :as cljs]
-            [cider.nrepl.middleware.util.misc :refer [err-info]]
+            [clojure.stacktrace :refer [print-cause-trace]]
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.misc :refer [response-for]]
             [clojure.tools.nrepl.transport :as transport]
@@ -13,6 +13,12 @@
 (defn- require-and-resolve [sym]
   (require (symbol (namespace sym)))
   (resolve sym))
+
+(defn err-info
+  [ex status]
+  {:ex (str (class ex))
+   :err (with-out-str (print-cause-trace ex))
+   :status #{status :done}})
 
 (defmacro ^:private with-errors-being-passed-on [transport msg & body]
   `(try


### PR DESCRIPTION
This function has been removed from cider-nrepl.

Fixes #212

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] ~You've added tests (if possible) to cover your change(s)~
- [X] All tests are passing (run `lein do clean, test`)
- [X] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [ ] ~You've updated the changelog (if adding/changing user-visible functionality)~
- [ ] ~You've updated the readme (if adding/changing user-visible functionality)~