### PR TITLE
[Fix #219] deps.edn as recognizable project root

### DIFF
--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -71,7 +71,7 @@
          start (if (fs/directory? path-or-file-in-project)
                  path-or-file-in-project
                  (fs/parent path-or-file-in-project))
-         names-at-root #{"project.clj" "build.boot" "build.gradle" "pom.xml"}
+         names-at-root #{"project.clj" "build.boot" "build.gradle" "pom.xml" "deps.edn"}
          known-root-file? (fn [^File f] (some (fn [known-root-name]
                                                 (.endsWith (.getCanonicalPath f)
                                                            known-root-name))


### PR DESCRIPTION
deps.edn added as a one more recognizable project root.