### PR TITLE
Use orchard for classpath information

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  ^:source-dep [org.clojure/tools.analyzer.jvm "0.7.1"]
                  ^:source-dep [org.clojure/tools.namespace  "0.3.0-alpha3"]
                  ^:source-dep [org.clojure/tools.reader "1.1.1"]
-                 ^:source-dep [org.clojure/java.classpath "0.2.3"]
+                 ^:source-dep [cider/orchard "0.2.0"]
                  ^:source-dep [lein-cljfmt "0.3.0"]
                  ^:source-dep [me.raynes/fs "1.4.6"]
                  ^:source-dep [rewrite-clj "0.6.0"]

--- a/src/refactor_nrepl/ns/slam/hound/search.clj
+++ b/src/refactor_nrepl/ns/slam/hound/search.clj
@@ -3,7 +3,7 @@
 ;;;; Distributed under the Eclipse Public License, the same as Clojure.
 (ns refactor-nrepl.ns.slam.hound.search
   "Search the classpath for vars and classes."
-  (:require [clojure.java.classpath :as cp]
+  (:require [orchard.classpath]
             [clojure.java.io :refer [file]]
             [clojure.string :as string])
   (:import
@@ -111,7 +111,7 @@
   (into (map #(System/getProperty %) ["sun.boot.class.path"
                                       "java.ext.dirs"
                                       "java.class.path"])
-        (map #(.getName %) (cp/classpath-jarfiles))))
+        (map #(.getName %) (orchard.classpath/classpath-jarfiles))))
 
 (defn- get-available-classes []
   (into ()


### PR DESCRIPTION
Orchard has encapsulated the boot information already, so that code can
go. Orchard has already upgraded to support Java9+ too. Additionally,
orchard will receive more long-term maintenance of this code.