### PR TITLE
Fix #235. allow gen-class methods metadata extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ The `clean-ns` op will perform the following cleanups on an ns form:
 * Remove any unused namespaces, referred symbols or imported classes.
 * Remove any duplication in the :require and :import form.
 * Prune or remove any `:rename` clause.
+* Use the shorthand version of metadata found if possible, and sort it
+  alphabetically
 
 The `clean-ns` requires a `path` which is the path to the file containing the `ns` to be operated upon.
 

--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -262,11 +262,12 @@
                     (StringReader.)
                     (PushbackReader.)
                     parse/read-ns-decl)
-        meta? (second ns-form)          ;easily available
-        shorthand-meta? (re-seq #"(?:(ns\s+.*?\^:)|\G\s*\^:)(\w+)" ns-string)]
-    {:ns-meta (merge meta?
-                     (into {} (for [match shorthand-meta?]
-                                [(keyword (nth match 2)) true])))
+        meta (if (map? (second ns-form)) (second ns-form)) ;easily available
+        shorthand-meta (re-seq #"(?:(ns\s+.*?\^:)|\G\s*\^:)(\w+)" ns-string)
+        shorthand->longhand (into {} (for [match shorthand-meta]
+                                       [(keyword (nth match 2)) true]))]
+    {:ns-meta (merge meta (when-not (empty? shorthand->longhand)
+                            shorthand->longhand))
      :gc-methods-meta (extract-gen-class-methods-meta ns-form)}))
 
 (defn extract-gen-class-methods-meta

--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -266,8 +266,8 @@
         shorthand-meta (re-seq #"(?:(ns\s+.*?\^:)|\G\s*\^:)(\w+)" ns-string)
         shorthand->longhand (into {} (for [match shorthand-meta]
                                        [(keyword (nth match 2)) true]))]
-    {:ns-meta (merge meta (when-not (empty? shorthand->longhand)
-                            shorthand->longhand))
+    {:top-level-meta (merge meta (when-not (empty? shorthand->longhand)
+                                   shorthand->longhand))
      :gc-methods-meta (extract-gen-class-methods-meta ns-form)}))
 
 (defn extract-gen-class-methods-meta

--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -286,7 +286,7 @@
                              (.indexOf gen-class :methods)
                              -1))]
     (if-not (zero? methods_index)
-      (map #(meta %) (nth gen-class methods_index))
+      (apply merge (map #(meta %) (nth gen-class methods_index)))
       nil)))
 
 (defn read-ns-form-with-meta

--- a/src/refactor_nrepl/ns/pprint.clj
+++ b/src/refactor_nrepl/ns/pprint.clj
@@ -2,9 +2,9 @@
   (:require [cljfmt.core :as fmt]
             [clojure
              [pprint :refer [pprint]]
-             [data :as data]
              [string :as str]]
             [refactor-nrepl.core :as core :refer [prefix-form?]])
+
   (:import java.util.regex.Pattern))
 
 (defn- libspec-vectors-last [libspecs]
@@ -64,9 +64,11 @@
       (if (= key :methods)
         (do
           (print key "[")
-          (doseq [method val]             ;val are all the methods
-            (pprint-meta (last (data/diff (meta method) metadata)))
-            (print method))
+          (doseq [method val]           ;val are all the methods
+            (pprint-meta (filter (fn [[k v]]
+                                   (contains? metadata k))
+                                 (meta method)))
+            (print method))             ;TODO add newline here
           (print "]"))
         (print key val))
       (when (= idx (dec (count (partition 2 elems))))

--- a/src/refactor_nrepl/util.clj
+++ b/src/refactor_nrepl/util.clj
@@ -1,4 +1,5 @@
 (ns refactor-nrepl.util
+  (:require [clojure.string :as string])
   (:import java.util.regex.Pattern))
 
 (defn normalize-to-unix-path
@@ -41,3 +42,13 @@
     (if (seq xs)
       (apply conj coll xs)
       coll)))
+
+(defn replace-last
+  "Replaces the last instance of match from the string s with rep"
+  [s match rep]
+  (as-> s _
+    (reverse _)
+    (apply str _)
+    (string/replace-first _ match rep)
+    (reverse _)
+    (apply str _)))

--- a/test/refactor_nrepl/ns/clean_ns_test.clj
+++ b/test/refactor_nrepl/ns/clean_ns_test.clj
@@ -38,8 +38,11 @@
 (def cljc-ns-same-clj-cljs-cleaned (core/read-ns-form-with-meta (absolute-path "test/resources/cljcns_same_clj_cljs_cleaned.cljc")))
 
 (def ns-with-shorthand-meta (clean-msg "test/resources/ns_with_shorthand_meta.clj"))
-
 (def ns-with-multiple-shorthand-meta (clean-msg "test/resources/ns_with_multiple_shorthand_meta.clj"))
+(def ns-with-gen-class-methods-meta (clean-msg "test/resources/ns_with_gen_class_methods_meta.clj"))
+(def ns-with-gen-class-methods-meta-clean (clean-msg "test/resources/ns_with_gen_class_methods_meta_clean.clj"))
+(def ns-with-lots-of-meta (clean-msg "test/resources/ns_with_lots_of_meta.clj"))
+(def ns-with-lots-of-meta-clean (clean-msg "test/resources/ns_with_lots_of_meta_clean.clj"))
 
 (def ns-with-inner-classes (clean-msg "test/resources/ns_with_inner_classes.clj"))
 
@@ -199,10 +202,20 @@
   (let [cleaned (pprint-ns (clean-ns ns-with-shorthand-meta))]
     (is (re-find #"\^:automation" cleaned))))
 
-(deftest preservres-multiple-shortand-meta
+(deftest preserves-multiple-shortand-meta
   (let [cleaned (pprint-ns (clean-ns ns-with-multiple-shorthand-meta))]
     (is (re-find #"\^:automation" cleaned))
     (is (re-find #"\^:multiple" cleaned))))
+
+(deftest preserves-gen-class-methods-meta
+  (let [actual (pprint-ns (clean-ns ns-with-gen-class-methods-meta))
+        expected (slurp (:path ns-with-gen-class-methods-meta-clean))]
+    (is (= expected actual))))
+
+(deftest preserves-all-meta
+  (let [actual (pprint-ns (clean-ns ns-with-lots-of-meta))
+        expected (slurp (:path ns-with-lots-of-meta-clean))]
+    (is (= expected actual))))
 
 (deftest does-not-remove-dollar-sign-if-valid-symbol
   (let [cleaned (pprint-ns (clean-ns ns-using-dollar))]

--- a/test/resources/ns_with_gen_class_methods_meta.clj
+++ b/test/resources/ns_with_gen_class_methods_meta.clj
@@ -1,0 +1,12 @@
+(ns ns-with-gen-class-methods-meta
+  (:gen-class
+   :methods [^:static [foo [String] String]
+             ^{:test true} [bar [String] String]
+             ^{:other "text"} [baz [String] String]]
+   :name Name)
+  (:require [clojure.string :as s]
+            [clojure.pprint :refer [fresh-line]]))
+
+(defn useit
+  []
+  (fresh-line))

--- a/test/resources/ns_with_gen_class_methods_meta_clean.clj
+++ b/test/resources/ns_with_gen_class_methods_meta_clean.clj
@@ -1,0 +1,7 @@
+(ns ns-with-gen-class-methods-meta
+  (:gen-class
+   :methods [^:static [foo [String] String]
+             ^:test [bar [String] String]
+             ^{:other "text"} [baz [String] String]]
+   :name Name)
+  (:require [clojure.pprint :refer [fresh-line]]))

--- a/test/resources/ns_with_lots_of_meta.clj
+++ b/test/resources/ns_with_lots_of_meta.clj
@@ -1,0 +1,12 @@
+(ns ^:md1 ^:md2 ^{:longhand "as well" :really? "yes" :ok true} ns-with-gen-class-methods-meta
+  (:gen-class
+   :methods [^:static [foo [String] String]
+             ^{:test true} [bar [String] String]
+             ^{:other "text"} [baz [String] String]]
+   :name Name)
+  (:require [clojure.string :as s]
+            [clojure.pprint :refer [fresh-line]]))
+
+(defn useit
+  []
+  (fresh-line))

--- a/test/resources/ns_with_lots_of_meta_clean.clj
+++ b/test/resources/ns_with_lots_of_meta_clean.clj
@@ -1,0 +1,9 @@
+(ns ^:md1 ^:md2 ^:ok ^{:longhand "as well"
+                       :really? "yes"}
+ ns-with-gen-class-methods-meta
+  (:gen-class
+   :methods [^:static [foo [String] String]
+             ^:test [bar [String] String]
+             ^{:other "text"} [baz [String] String]]
+   :name Name)
+  (:require [clojure.pprint :refer [fresh-line]]))


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

**Original:**
- Was only getting ns metadata
- Using positional information for longhand metadata: assuming it was given right after the ns form (in second position)
- Using a regex on the ns-as-string for shorthand metadata.
- Got confused about gen-class methods metadata (because of the regex) and placed it at the top, thinking it was ns top level metadata.

**PR:**
- Gets metadata from ns and (:gen-class :methods)
- Using (meta), so shorthand and longhand can be mixed
- Prints out the metadata in a sorted order, checking if it can be written in shorthand notation. So `^{:static true}` becomes `^:static`
- Can make newlines (as an option) between entries of longhand metadata: 
```clojure
^{:doc "Some doc"
  :author "Author"}
```
OR
```clojure
^{:doc "Short doc" :author "Author"}
```

I added some tests where you can check the functionality. All tests pass.
