### PR TITLE
Fix a NullPointerException on jdk11

### DIFF
--- a/src/refactor_nrepl/ns/slam/hound/search.clj
+++ b/src/refactor_nrepl/ns/slam/hound/search.clj
@@ -108,9 +108,9 @@
    (StringTokenizer. path-str File/pathSeparator)))
 
 (defn all-classpath-entries []
-  (into (map #(System/getProperty %) ["sun.boot.class.path"
-                                      "java.ext.dirs"
-                                      "java.class.path"])
+  (into (keep #(System/getProperty %) ["sun.boot.class.path"
+                                       "java.ext.dirs"
+                                       "java.class.path"])
         (map #(.getName %) (orchard.classpath/classpath-jarfiles))))
 
 (defn- get-available-classes []


### PR DESCRIPTION
JDK11 doesn't have system properties "sun.boot.class.path" or "java.ext.dirs".  This fix avoids a null pointer exception in `refactor-nrepl.ns.slam.hound.search`.