### PR TITLE
CircleCI migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,11 +116,14 @@ jobs:
           cache_version: << parameters.clojure_version >>
           steps:
             - run:
-                name: Installing source-deps
-                command: lein source-deps :prefix-exclusions "[\"classlojure\"]"
-            - run:
                 name: Running tests
-                command: lein with-profile +<< parameters.clojure_version >>,+plugin.mranderson/config test
+                command: make test
+            # - run:
+            #     name: Installing source-deps
+            #     command: lein source-deps :prefix-exclusions "[\"classlojure\"]"
+            # - run:
+            #     name: Running tests
+            #     command: lein with-profile +<< parameters.clojure_version >>,+plugin.mranderson/config test
 
 ######################################################################
 #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,38 +144,38 @@ workflows:
   version: 2.1
   ci-test-matrix:
     jobs:
-      - test_code:
-          name: Java 8, Clojure 1.8
-          clojure_version: "1.8"
-          jdk_version: openjdk8
+      # - test_code:
+      #     name: Java 8, Clojure 1.8
+      #     clojure_version: "1.8"
+      #     jdk_version: openjdk8
       - test_code:
           name: Java 8, Clojure 1.9
           clojure_version: "1.9"
           jdk_version: openjdk8
-      - test_code:
-          name: Java 8, Clojure 1.10
-          clojure_version: "1.10"
-          jdk_version: openjdk8
-      - test_code:
-          name: Java 8, Clojure master
-          clojure_version: "master"
-          jdk_version: openjdk8
-      - test_code:
-          name: Java 11, Clojure 1.8
-          clojure_version: "1.8"
-          jdk_version: openjdk11
+      # - test_code:
+      #     name: Java 8, Clojure 1.10
+      #     clojure_version: "1.10"
+      #     jdk_version: openjdk8
+      # - test_code:
+      #     name: Java 8, Clojure master
+      #     clojure_version: "master"
+      #     jdk_version: openjdk8
+      # - test_code:
+      #     name: Java 11, Clojure 1.8
+      #     clojure_version: "1.8"
+      #     jdk_version: openjdk11
       - test_code:
           name: Java 11, Clojure 1.9
           clojure_version: "1.9"
           jdk_version: openjdk11
-      - test_code:
-          name: Java 11, Clojure 1.10
-          clojure_version: "1.10"
-          jdk_version: openjdk11
-      - test_code:
-          name: Java 11, Clojure master
-          clojure_version: "master"
-          jdk_version: openjdk11
+      # - test_code:
+      #     name: Java 11, Clojure 1.10
+      #     clojure_version: "1.10"
+      #     jdk_version: openjdk11
+      # - test_code:
+      #     name: Java 11, Clojure master
+      #     clojure_version: "master"
+      #     jdk_version: openjdk11
       # - util_job:
       #     name: Code Linting
       #     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,186 @@
+version: 2.1
+
+######################################################################
+#
+# Start of general purpose config. These can plausibly go into orbs
+#
+######################################################################
+
+# Default settings for executors
+
+defaults: &defaults
+  working_directory: ~/repo
+  environment:
+    LEIN_ROOT: "true"   # we intended to run lein as root
+    JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
+
+# Runners for OpenJDK 8 and 11
+
+executors:
+  openjdk8:
+    docker:
+      - image: circleci/clojure:openjdk-8-lein-2.9.1
+    <<: *defaults
+  openjdk11:
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.1
+    <<: *defaults
+
+# Runs a given set of steps, with some standard pre- and post-
+# steps, including restoring of cache, saving of cache.
+#
+# we also install `make` here.
+#
+# Adapted from https://github.com/lambdaisland/meta/blob/master/circleci/clojure_orb.yml
+
+commands:
+  with_cache:
+    description: |
+      Run a set of steps with Maven dependencies and Clojure classpath cache
+      files cached.
+      This command restores ~/.m2 and .cpcache if they were previously cached,
+      then runs the provided steps, and finally saves the cache.
+      The cache-key is generated based on the contents of `deps.edn` present in
+      the `working_directory`.
+    parameters:
+      steps:
+        type: steps
+      files:
+        description: Files to consider when creating the cache key
+        type: string
+        default: "deps.edn project.clj build.boot"
+      cache_version:
+        type: string
+        description: "Change this value to force a cache update"
+        default: "1"
+    steps:
+      - run:
+          name: Install make
+          command: |
+            sudo apt-get install make
+      - run:
+          name: Generate Cache Checksum
+          command: |
+            for file in << parameters.files >>
+            do
+              find . -name $file -exec cat {} +
+            done | shasum | awk '{print $1}' > /tmp/clojure_cache_seed
+      - restore_cache:
+          key: clojure-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
+      - steps: << parameters.steps >>
+      - save_cache:
+          paths:
+            - ~/.m2
+            - .cpcache
+            - repo
+          key: clojure-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
+
+# The jobs are relatively simple. One runs utility commands against
+# latest stable JDK + Clojure, the other against specified versions
+
+jobs:
+
+  util_job:
+    description: |
+      Running utility commands/checks (linter etc.)
+      Always uses Java11 and Clojure 1.10
+    parameters:
+      steps:
+        type: steps
+    executor: openjdk11
+    environment:
+      VERSION: "1.10"
+    steps:
+      - checkout
+      - with_cache:
+          cache_version: "1.10"
+          steps: << parameters.steps >>
+
+
+  test_code:
+    description: |
+      Run tests against given version of JDK and Clojure
+    parameters:
+      jdk_version:
+        description: Version of JDK to test against
+        type: string
+      clojure_version:
+        description: Version of Clojure to test against
+        type: string
+    executor: << parameters.jdk_version >>
+    environment:
+      VERSION: << parameters.clojure_version >>
+    steps:
+      - checkout
+      - with_cache:
+          cache_version: << parameters.clojure_version >>
+          steps:
+            - run:
+                name: Installing source-deps
+                command: lein source-deps :prefix-exclusions "[\"classlojure\"]"
+            - run:
+                name: Running tests
+                command: lein with-profile +<< parameters.clojure_version >>,+plugin.mranderson/config test
+
+######################################################################
+#
+# End general purpose configs
+#
+######################################################################
+
+
+# The ci-test-matrix does the following:
+#
+# - run tests against the target matrix
+#   - Java 8 and 11
+#   - Clojure 1.8, 1.9, 1.10, master
+# - linter, eastwood and cljfmt
+# - runs code coverage report
+
+workflows:
+  version: 2.1
+  ci-test-matrix:
+    jobs:
+      - test_code:
+          name: Java 8, Clojure 1.8
+          clojure_version: "1.8"
+          jdk_version: openjdk8
+      - test_code:
+          name: Java 8, Clojure 1.9
+          clojure_version: "1.9"
+          jdk_version: openjdk8
+      - test_code:
+          name: Java 8, Clojure 1.10
+          clojure_version: "1.10"
+          jdk_version: openjdk8
+      - test_code:
+          name: Java 8, Clojure master
+          clojure_version: "master"
+          jdk_version: openjdk8
+      - test_code:
+          name: Java 11, Clojure 1.8
+          clojure_version: "1.8"
+          jdk_version: openjdk11
+      - test_code:
+          name: Java 11, Clojure 1.9
+          clojure_version: "1.9"
+          jdk_version: openjdk11
+      - test_code:
+          name: Java 11, Clojure 1.10
+          clojure_version: "1.10"
+          jdk_version: openjdk11
+      - test_code:
+          name: Java 11, Clojure master
+          clojure_version: "master"
+          jdk_version: openjdk11
+      # - util_job:
+      #     name: Code Linting
+      #     steps:
+      #       - run:
+      #           name: Running Eastwood
+      #           command: |
+      #             make eastwood
+      #       - run:
+      #           name: Running cljfmt
+      #           command: |
+      #             make cljfmt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,11 @@ defaults: &defaults
 executors:
   openjdk8:
     docker:
-      - image: circleci/clojure:openjdk-8-lein-2.9.1
+      - image: circleci/clojure:openjdk-8-lein-2.9.1-node
     <<: *defaults
   openjdk11:
     docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.1
+      - image: circleci/clojure:openjdk-11-lein-2.9.1-node
     <<: *defaults
 
 # Runs a given set of steps, with some standard pre- and post-
@@ -116,6 +116,9 @@ jobs:
           cache_version: << parameters.clojure_version >>
           steps:
             - run:
+                name: Downloading Source deps
+                command: make source-deps
+            - run:
                 name: Running tests
                 command: make test
             # - run:
@@ -144,18 +147,18 @@ workflows:
   version: 2.1
   ci-test-matrix:
     jobs:
-      # - test_code:
-      #     name: Java 8, Clojure 1.8
-      #     clojure_version: "1.8"
-      #     jdk_version: openjdk8
+      - test_code:
+          name: Java 8, Clojure 1.8
+          clojure_version: "1.8"
+          jdk_version: openjdk8
       - test_code:
           name: Java 8, Clojure 1.9
           clojure_version: "1.9"
           jdk_version: openjdk8
-      # - test_code:
-      #     name: Java 8, Clojure 1.10
-      #     clojure_version: "1.10"
-      #     jdk_version: openjdk8
+      - test_code:
+          name: Java 8, Clojure 1.10
+          clojure_version: "1.10"
+          jdk_version: openjdk8
       # - test_code:
       #     name: Java 8, Clojure master
       #     clojure_version: "master"
@@ -164,10 +167,10 @@ workflows:
       #     name: Java 11, Clojure 1.8
       #     clojure_version: "1.8"
       #     jdk_version: openjdk11
-      - test_code:
-          name: Java 11, Clojure 1.9
-          clojure_version: "1.9"
-          jdk_version: openjdk11
+      # - test_code:
+      #     name: Java 11, Clojure 1.9
+      #     clojure_version: "1.9"
+      #     jdk_version: openjdk11
       # - test_code:
       #     name: Java 11, Clojure 1.10
       #     clojure_version: "1.10"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,18 +157,18 @@ workflows:
       #     name: Java 8, Clojure master
       #     clojure_version: "master"
       #     jdk_version: openjdk8
-      # - test_code:
-      #     name: Java 11, Clojure 1.8
-      #     clojure_version: "1.8"
-      #     jdk_version: openjdk11
-      # - test_code:
-      #     name: Java 11, Clojure 1.9
-      #     clojure_version: "1.9"
-      #     jdk_version: openjdk11
-      # - test_code:
-      #     name: Java 11, Clojure 1.10
-      #     clojure_version: "1.10"
-      #     jdk_version: openjdk11
+      - test_code:
+          name: Java 11, Clojure 1.8
+          clojure_version: "1.8"
+          jdk_version: openjdk11
+      - test_code:
+          name: Java 11, Clojure 1.9
+          clojure_version: "1.9"
+          jdk_version: openjdk11
+      - test_code:
+          name: Java 11, Clojure 1.10
+          clojure_version: "1.10"
+          jdk_version: openjdk11
       # - test_code:
       #     name: Java 11, Clojure master
       #     clojure_version: "master"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,12 +121,6 @@ jobs:
             - run:
                 name: Running tests
                 command: make test
-            # - run:
-            #     name: Installing source-deps
-            #     command: lein source-deps :prefix-exclusions "[\"classlojure\"]"
-            # - run:
-            #     name: Running tests
-            #     command: lein with-profile +<< parameters.clojure_version >>,+plugin.mranderson/config test
 
 ######################################################################
 #

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ JAVA_VERSION := $(shell lein with-profile +sysutils \
                         sysutils :java-version-simple | cut -d " " -f 2)
 TEST_SELECTOR := :java$(JAVA_VERSION)
 
-test:
+source-deps:
 	lein source-deps :prefix-exclusions "[\"classlojure\"]"
+
+test:
 	lein with-profile +$(VERSION),+plugin.mranderson/config test
 
 # Documentation management via autodoc (https://github.com/plexus/autodoc)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,73 @@
+.PHONY: test docs eastwood cljfmt cloverage release deploy clean
+
+VERSION ?= 1.9
+
+# Some tests need to be filtered based on JVM version.  This selector
+# will be mapped to a function in project.clj, and that function
+# determines which `deftest` to run based on their metadata.
+JAVA_VERSION := $(shell lein with-profile +sysutils \
+                        sysutils :java-version-simple | cut -d " " -f 2)
+TEST_SELECTOR := :java$(JAVA_VERSION)
+
+test:
+	lein source-deps :prefix-exclusions "[\"classlojure\"]"
+	lein with-profile +$(VERSION)+plugin.mranderson/config test
+
+# Documentation management via autodoc (https://github.com/plexus/autodoc)
+# Pin a specific commit in that repo to prevent accidental changes in
+# that upstream project breaking our CI. Periodically update the URL
+# below as needed.
+
+autodoc.sh:
+	curl -L https://raw.githubusercontent.com/plexus/autodoc/a540761f/autodoc.sh -o $@
+	chmod +x $@
+
+docs: autodoc.sh
+	@if [ "$(TRAVIS)" = "true" ] && [ "$(TRAVIS_PULL_REQUEST)" = "false" ]; then \
+	    git remote set-url --push origin \
+	        https://$(GH_USER):$(GH_PASSWORD)@github.com/$(TRAVIS_REPO_SLUG).git; \
+	    AUTODOC_SUBDIR="$(TRAVIS_BRANCH)" \
+	    AUTODOC_CMD="lein with-profile +$(VERSION),+codox codox" ./autodoc.sh ; \
+	else \
+	    AUTODOC_SUBDIR=`git rev-parse --abbrev-ref HEAD` \
+	    AUTODOC_CMD="lein with-profile +$(VERSION),+codox codox" ./autodoc.sh ; \
+	fi
+
+# Eastwood can't handle orchard.java.parser at the moment, because
+# tools.jar isn't in the classpath when Eastwood runs.
+
+eastwood:
+	lein with-profile +$(VERSION),+eastwood eastwood \
+	     "{:exclude-namespaces [orchard.java.parser]}"
+
+cljfmt:
+	lein with-profile +$(VERSION),+cljfmt cljfmt check
+
+# Cloverage can't handle some of the code in this project.  For now we
+# must filter problematic namespaces (`-e`) and tests (`-t`) from
+# instrumentation. Note: this means for now coverage reporting isn't
+# exact. See issue cider-nrepl/#457 for background.
+
+cloverage:
+	lein with-profile +$(VERSION),+cloverage cloverage --codecov \
+	     -e "orchard.java.parser"
+
+# When releasing, the BUMP variable controls which field in the
+# version string will be incremented in the *next* snapshot
+# version. Typically this is either "major", "minor", or "patch".
+
+BUMP ?= patch
+
+release:
+	lein with-profile +$(VERSION) release $(BUMP)
+
+# Deploying requires the caller to set environment variables as
+# specified in project.clj to provide a login and password to the
+# artifact repository.
+
+deploy:
+	lein with-profile +$(VERSION) deploy clojars
+
+clean:
+	lein clean
+	rm -rf gh-pages autodoc.sh

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,6 @@
-.PHONY: test docs eastwood cljfmt cloverage release deploy clean
+.PHONY: source-deps test release deploy clean
 
 VERSION ?= 1.9
-
-# Some tests need to be filtered based on JVM version.  This selector
-# will be mapped to a function in project.clj, and that function
-# determines which `deftest` to run based on their metadata.
-JAVA_VERSION := $(shell lein with-profile +sysutils \
-                        sysutils :java-version-simple | cut -d " " -f 2)
-TEST_SELECTOR := :java$(JAVA_VERSION)
 
 source-deps:
 	lein source-deps :prefix-exclusions "[\"classlojure\"]"
@@ -15,44 +8,6 @@ source-deps:
 test:
 	lein with-profile +$(VERSION),+plugin.mranderson/config test
 
-# Documentation management via autodoc (https://github.com/plexus/autodoc)
-# Pin a specific commit in that repo to prevent accidental changes in
-# that upstream project breaking our CI. Periodically update the URL
-# below as needed.
-
-autodoc.sh:
-	curl -L https://raw.githubusercontent.com/plexus/autodoc/a540761f/autodoc.sh -o $@
-	chmod +x $@
-
-docs: autodoc.sh
-	@if [ "$(TRAVIS)" = "true" ] && [ "$(TRAVIS_PULL_REQUEST)" = "false" ]; then \
-	    git remote set-url --push origin \
-	        https://$(GH_USER):$(GH_PASSWORD)@github.com/$(TRAVIS_REPO_SLUG).git; \
-	    AUTODOC_SUBDIR="$(TRAVIS_BRANCH)" \
-	    AUTODOC_CMD="lein with-profile +$(VERSION),+codox codox" ./autodoc.sh ; \
-	else \
-	    AUTODOC_SUBDIR=`git rev-parse --abbrev-ref HEAD` \
-	    AUTODOC_CMD="lein with-profile +$(VERSION),+codox codox" ./autodoc.sh ; \
-	fi
-
-# Eastwood can't handle orchard.java.parser at the moment, because
-# tools.jar isn't in the classpath when Eastwood runs.
-
-eastwood:
-	lein with-profile +$(VERSION),+eastwood eastwood \
-	     "{:exclude-namespaces [orchard.java.parser]}"
-
-cljfmt:
-	lein with-profile +$(VERSION),+cljfmt cljfmt check
-
-# Cloverage can't handle some of the code in this project.  For now we
-# must filter problematic namespaces (`-e`) and tests (`-t`) from
-# instrumentation. Note: this means for now coverage reporting isn't
-# exact. See issue cider-nrepl/#457 for background.
-
-cloverage:
-	lein with-profile +$(VERSION),+cloverage cloverage --codecov \
-	     -e "orchard.java.parser"
 
 # When releasing, the BUMP variable controls which field in the
 # version string will be incremented in the *next* snapshot
@@ -72,4 +27,3 @@ deploy:
 
 clean:
 	lein clean
-	rm -rf gh-pages autodoc.sh

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TEST_SELECTOR := :java$(JAVA_VERSION)
 
 test:
 	lein source-deps :prefix-exclusions "[\"classlojure\"]"
-	lein with-profile +$(VERSION)+plugin.mranderson/config test
+	lein with-profile +$(VERSION),+plugin.mranderson/config test
 
 # Documentation management via autodoc (https://github.com/plexus/autodoc)
 # Pin a specific commit in that repo to prevent accidental changes in

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: source-deps test release deploy clean
 
-VERSION ?= 1.9
+VERSION ?= 1.10
 
 source-deps:
 	lein source-deps :prefix-exclusions "[\"classlojure\"]"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/clojure-emacs/refactor-nrepl.png?branch=master)](https://travis-ci.org/clojure-emacs/refactor-nrepl)
+[![CircleCI](https://circleci.com/gh/clojure-emacs/refactor-nrepl/tree/master.svg?style=svg)](https://circleci.com/gh/clojure-emacs/refactor-nrepl/tree/master)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/clojure-emacs/refactor-nrepl?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 # Refactor nREPL

--- a/project.clj
+++ b/project.clj
@@ -31,10 +31,10 @@
                     :src-paths ["test/resources"]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/clojurescript "1.8.51"]
-                                  #_[javax.xml.bind/jaxb-api "2.3.1"]]}
+                                  [javax.xml.bind/jaxb-api "2.3.1"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]
                                   [org.clojure/clojurescript "1.9.908"]
-                                  #_[javax.xml.bind/jaxb-api "2.3.1"]]}
+                                  [javax.xml.bind/jaxb-api "2.3.1"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]
                                    [org.clojure/clojurescript "1.10.63"]]}
              :dev {:plugins [[jonase/eastwood "0.2.0"]]

--- a/project.clj
+++ b/project.clj
@@ -41,5 +41,5 @@
                    :java-source-paths ["test/java"]
                    :resource-paths ["test/resources"
                                     "test/resources/testproject/src"]
-                   :repositories [["snapshots" "http://oss.sonatype.org/content/repositories/snapshots"]]}}
+                   :repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots"]]}}
   :jvm-opts ["-Djava.net.preferIPv4Stack=true"])

--- a/project.clj
+++ b/project.clj
@@ -29,8 +29,14 @@
                                        [org.clojure/clojure "1.8.0"]]}
              :test {:dependencies [[print-foo "1.0.2"]]
                     :src-paths ["test/resources"]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]
+                                  [org.clojure/clojurescript "1.8.51"]
+                                  #_[javax.xml.bind/jaxb-api "2.3.1"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]
-                                  [org.clojure/clojurescript "1.9.908"]]}
+                                  [org.clojure/clojurescript "1.9.908"]
+                                  #_[javax.xml.bind/jaxb-api "2.3.1"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]
+                                   [org.clojure/clojurescript "1.10.63"]]}
              :dev {:plugins [[jonase/eastwood "0.2.0"]]
                    :global-vars {*warn-on-reflection* true}
                    :dependencies [[org.clojure/clojurescript "1.9.89"]


### PR DESCRIPTION
I added a Makefile, in attempt to bring this more in line with how the other Clojure projects in the org works. Very similar CircleCI config.

https://circleci.com/gh/shen-tian/workflows/refactor-nrepl

As it stood, the project was tested on Oracle Java 8 and Clojure 1.8 and 1.9 in a single job. I've move that over to OpenJDK 8, added Clojure 1.10 tests, and split them up into separate jobs.

I've tried to add Java 11 tests, but they are not passing. Will jot down some notes so we can investigate. Given that we are not testing on Java 11 right now, this PR is good to go.

Edit: a quick look suggests that #241 addresses the Java 11 issues, as that function is where the tests are failing.