### PR TITLE
Adding cljfmt check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,14 +170,14 @@ workflows:
       #     name: Java 11, Clojure master
       #     clojure_version: "master"
       #     jdk_version: openjdk11
-      # - util_job:
-      #     name: Code Linting
-      #     steps:
-      #       - run:
-      #           name: Running Eastwood
-      #           command: |
-      #             make eastwood
-      #       - run:
-      #           name: Running cljfmt
-      #           command: |
-      #             make cljfmt
+      - util_job:
+          name: Code Linting
+          steps:
+            # - run:
+            #     name: Running Eastwood
+            #     command: |
+            #       make eastwood
+            - run:
+                name: Running cljfmt
+                command: |
+                  make cljfmt

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ source-deps: .source-deps
 test: .source-deps
 	lein with-profile +$(VERSION),+plugin.mranderson/config test
 
+cljfmt:
+	lein with-profile +$(VERSION),+cljfmt cljfmt check
 
 # When releasing, the BUMP variable controls which field in the
 # version string will be incremented in the *next* snapshot

--- a/project.clj
+++ b/project.clj
@@ -47,5 +47,11 @@
                    :java-source-paths ["test/java"]
                    :resource-paths ["test/resources"
                                     "test/resources/testproject/src"]
-                   :repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots"]]}}
+                   :repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots"]]}
+             :cljfmt [:test
+                      {:plugins [[lein-cljfmt "0.6.4"]]
+                       :cljfmt {:indents {as-> [[:inner 0]]
+                                          with-debug-bindings [[:inner 0]]
+                                          merge-meta [[:inner 0]]
+                                          try-if-let [[:block 1]]}}}]}
   :jvm-opts ["-Djava.net.preferIPv4Stack=true"])

--- a/project.clj
+++ b/project.clj
@@ -51,6 +51,9 @@
              :cljfmt [:test
                       {:plugins [[lein-cljfmt "0.6.4"]]
                        :cljfmt {:indents {as-> [[:inner 0]]
+                                          as->* [[:inner 0]]
+                                          cond-> [[:inner 0]]
+                                          cond->* [[:inner 0]]
                                           with-debug-bindings [[:inner 0]]
                                           merge-meta [[:inner 0]]
                                           try-if-let [[:block 1]]}}}]}

--- a/src/refactor_nrepl/config.clj
+++ b/src/refactor_nrepl/config.clj
@@ -2,8 +2,7 @@
 
 ;; NOTE: Update the readme whenever this map is changed
 (def ^:dynamic *config*
-  {
-   ;; Verbose setting for debugging.  The biggest effect this has is
+  {;; Verbose setting for debugging.  The biggest effect this has is
    ;; to not catch any exceptions to provide meaningful error
    ;; messages for the client.
 
@@ -23,8 +22,7 @@
    :libspec-whitelist ["^cljsjs"]
 
    ;; Regexes matching paths that are to be ignored
-   :ignore-paths []
-   })
+   :ignore-paths []})
 
 (defn opts-from-msg [msg]
   (into {}

--- a/src/refactor_nrepl/find/find_macros.clj
+++ b/src/refactor_nrepl/find/find_macros.clj
@@ -138,21 +138,21 @@
         macro-suffix (core/suffix macro-name)
         alias? ((get-ns-aliases libspecs) macro-prefix)]
     (when
-        (or
+     (or
          ;; locally defined macro
-         (and (= current-ns macro-prefix)
-              (= sym macro-suffix))
-         ;; fully qualified
-         (= sym macro-name)
-         ;; aliased
-         (when alias? (= sym (str alias? "/" macro-suffix)))
-         ;; referred
-         (when (macro-referred? libspecs macro-name)
+      (and (= current-ns macro-prefix)
            (= sym macro-suffix))
+         ;; fully qualified
+      (= sym macro-name)
+         ;; aliased
+      (when alias? (= sym (str alias? "/" macro-suffix)))
+         ;; referred
+      (when (macro-referred? libspecs macro-name)
+        (= sym macro-suffix))
          ;; I used to have a clause here for (:use .. :rename {...})
          ;; but :use is ;; basically deprecated and nobody used :rename to
          ;; begin with so I dropped it when the test failed.
-         )
+      )
       macro-name)))
 
 (defn- active-bindings

--- a/src/refactor_nrepl/find/find_symbol.clj
+++ b/src/refactor_nrepl/find/find_symbol.clj
@@ -126,8 +126,8 @@
                         {:file (.getCanonicalPath file)
                          :name fully-qualified-name
                          :match (match file-content
-                                       (:line-beg info)
-                                       (:line-end  info))}))]
+                                  (:line-beg info)
+                                  (:line-end  info))}))]
     (map gather locs)))
 
 (defn- find-global-symbol [file ns var-name ignore-errors]
@@ -214,8 +214,8 @@
                          {:name var-name
                           :file (.getCanonicalPath (java.io.File. file))
                           :match (match file-content
-                                        (:line-beg %)
-                                        (:line-end %))})
+                                   (:line-beg %)
+                                   (:line-end %))})
                  (find-nodes var-name
                              [top-level-form-ast]
                              #(and (#{:local :binding} (:op %))

--- a/src/refactor_nrepl/middleware.clj
+++ b/src/refactor_nrepl/middleware.clj
@@ -11,15 +11,15 @@
 ;; The assumption is that if someone is using old lein repl or boot repl
 ;; they'll end up using the tools.nrepl, otherwise the modern one.
 (when-not (resolve 'set-descriptor!)
-    (if (find-ns 'clojure.tools.nrepl)
-      (require
-       '[clojure.tools.nrepl.middleware :refer [set-descriptor!]]
-       '[clojure.tools.nrepl.misc :refer [response-for]]
-       '[clojure.tools.nrepl.transport :as transport])
-      (require
-       '[nrepl.middleware :refer [set-descriptor!]]
-       '[nrepl.misc :refer [response-for]]
-       '[nrepl.transport :as transport])))
+  (if (find-ns 'clojure.tools.nrepl)
+    (require
+     '[clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+     '[clojure.tools.nrepl.misc :refer [response-for]]
+     '[clojure.tools.nrepl.transport :as transport])
+    (require
+     '[nrepl.middleware :refer [set-descriptor!]]
+     '[nrepl.misc :refer [response-for]]
+     '[nrepl.transport :as transport])))
 
 (defn- require-and-resolve [sym]
   (require (symbol (namespace sym)))
@@ -183,15 +183,14 @@
          :status :done))
 
 (def ^:private find-used-publics
-  (delay (require-and-resolve 'refactor-nrepl.find.find-used-publics/find-used-publics) ))
+  (delay (require-and-resolve 'refactor-nrepl.find.find-used-publics/find-used-publics)))
 
 (defn- find-used-publics-reply [{:keys [transport] :as msg}]
   (reply transport msg
          :used-publics (serialize-response msg (@find-used-publics msg)) :status :done))
 
 (def refactor-nrepl-ops
-  {
-   "artifact-list" artifact-list-reply
+  {"artifact-list" artifact-list-reply
    "artifact-versions" artifact-versions-reply
    "clean-ns" clean-ns-reply
    "extract-definition" extract-definition-reply
@@ -205,8 +204,7 @@
    "find-used-publics" find-used-publics-reply
    "version" version-reply
    "warm-ast-cache" warm-ast-cache-reply
-   "warm-macro-occurrences-cache" warm-macro-occurrences-cache-reply
-   })
+   "warm-macro-occurrences-cache" warm-macro-occurrences-cache-reply})
 
 (defn wrap-refactor
   [handler]

--- a/src/refactor_nrepl/ns/prune_dependencies.clj
+++ b/src/refactor_nrepl/ns/prune_dependencies.clj
@@ -119,7 +119,7 @@
   (let [ns-name (str (:ns libspec))]
     (some (fn [^String pattern]
             (re-find (re-pattern pattern) ns-name))
-            (:libspec-whitelist config/*config*))))
+          (:libspec-whitelist config/*config*))))
 
 (defn- prune-libspec [symbols-in-file current-ns libspec]
   (if (libspec-should-never-be-pruned? libspec)

--- a/src/refactor_nrepl/ns/resolve_missing.clj
+++ b/src/refactor_nrepl/ns/resolve_missing.clj
@@ -35,7 +35,6 @@
              {:name candidate :type :class})))
        candidates))
 
-
 (defn- inlined-dependency? [candidate]
   (or (-> candidate str (.startsWith "deps."))
       (-> candidate str (.startsWith "mranderson"))

--- a/src/refactor_nrepl/ns/slam/hound/regrow.clj
+++ b/src/refactor_nrepl/ns/slam/hound/regrow.clj
@@ -90,9 +90,9 @@
         (coll? form) (into (empty form) (map f form))
         :else form)
       (as->* form'
-             (if-let [m (meta form)]
-               (with-meta form' m)
-               form'))))
+        (if-let [m (meta form)]
+          (with-meta form' m)
+          form'))))
 
 (defn- prewalk [f form]
   (walk (partial prewalk f) (f form)))
@@ -156,5 +156,5 @@
     :rename (reduce-kv
              (fn [s ns orig->rename]
                (cond->* s
-                        (some #{missing} (vals orig->rename)) (conj ns)))
+                 (some #{missing} (vals orig->rename)) (conj ns)))
              #{} (:rename old-ns-map))))

--- a/src/refactor_nrepl/ns/slam/hound/regrow.clj
+++ b/src/refactor_nrepl/ns/slam/hound/regrow.clj
@@ -60,8 +60,8 @@
 
 (defn- ns->symbols []
   (caching :ns->symbols
-    (let [xs (all-ns)]
-      (zipmap xs (mapv (comp set keys ns-publics) xs)))))
+           (let [xs (all-ns)]
+             (zipmap xs (mapv (comp set keys ns-publics) xs)))))
 
 (defn- symbols->ns-syms*
   ([]
@@ -78,7 +78,6 @@
 (defn- symbols->ns-syms []
   (cache-with-dirty-tracking :symbols->ns-syms symbols->ns-syms*))
 
-
 (defn- walk
   "Adapted from clojure.walk/walk and clojure.walk/prewalk; this version
   preserves metadata on compound forms."
@@ -91,9 +90,9 @@
         (coll? form) (into (empty form) (map f form))
         :else form)
       (as->* form'
-        (if-let [m (meta form)]
-          (with-meta form' m)
-          form'))))
+             (if-let [m (meta form)]
+               (with-meta form' m)
+               form'))))
 
 (defn- prewalk [f form]
   (walk (partial prewalk f) (f form)))
@@ -110,12 +109,12 @@
 
 (def ^:private ns-qualifed-syms
   (memoize
-    (fn [body]
-      (apply merge-with set/union {}
-             (for [ss (symbols-in-body body)
-                   :let [[_ alias var-name] (re-matches #"(.+)/(.+)" (str ss))]
-                   :when alias]
-               {(symbol alias) #{(symbol var-name)}})))))
+   (fn [body]
+     (apply merge-with set/union {}
+            (for [ss (symbols-in-body body)
+                  :let [[_ alias var-name] (re-matches #"(.+)/(.+)" (str ss))]
+                  :when alias]
+              {(symbol alias) #{(symbol var-name)}})))))
 
 (defn- ns-import-candidates
   "Search (all-ns) for imports that match missing-sym, returning a set of
@@ -131,12 +130,12 @@
 
 (defn- alias-candidates [type missing body]
   (set
-    (let [syms-with-alias (get (ns-qualifed-syms body) missing)]
-      (when (seq syms-with-alias)
-        (let [ns->syms (ns->symbols)]
-          (for [ns (all-ns)
-                :when (set/subset? syms-with-alias (ns->syms ns))]
-            (ns-name ns)))))))
+   (let [syms-with-alias (get (ns-qualifed-syms body) missing)]
+     (when (seq syms-with-alias)
+       (let [ns->syms (ns->symbols)]
+         (for [ns (all-ns)
+               :when (set/subset? syms-with-alias (ns->syms ns))]
+           (ns-name ns)))))))
 
 (defn candidates
   "Return a set of class or ns symbols that match the given constraints."
@@ -155,7 +154,7 @@
                    (alias-candidates type missing body')))))
     :refer (get (symbols->ns-syms) missing)
     :rename (reduce-kv
-              (fn [s ns orig->rename]
-                (cond->* s
-                  (some #{missing} (vals orig->rename)) (conj ns)))
-              #{} (:rename old-ns-map))))
+             (fn [s ns orig->rename]
+               (cond->* s
+                        (some #{missing} (vals orig->rename)) (conj ns)))
+             #{} (:rename old-ns-map))))

--- a/src/refactor_nrepl/plugin.clj
+++ b/src/refactor_nrepl/plugin.clj
@@ -44,7 +44,7 @@
 (defn- warn-no-project []
   (do
     (lein/warn "Warning: refactor-nrepl needs to run in the context of a project.")
-    (lein/warn "Warning: refactor-nrepl middleware won't be activated." )))
+    (lein/warn "Warning: refactor-nrepl middleware won't be activated.")))
 
 (defn middleware
   [project]

--- a/test/refactor_nrepl/artifacts_test.clj
+++ b/test/refactor_nrepl/artifacts_test.clj
@@ -20,9 +20,9 @@
 (deftest creates-a-map-of-artifacts
   (reset! artifacts/artifacts {})
   (with-redefs
-    [artifacts/get-clojars-artifacts! (constantly clojars-artifacts)
-     artifacts/get-mvn-artifacts! (constantly clojure-artifacts)
-     artifacts/get-mvn-versions! (constantly clojure-versions)]
+   [artifacts/get-clojars-artifacts! (constantly clojars-artifacts)
+    artifacts/get-mvn-artifacts! (constantly clojure-artifacts)
+    artifacts/get-mvn-versions! (constantly clojure-versions)]
 
     (is (#'artifacts/stale-cache?))
 

--- a/test/refactor_nrepl/core_test.clj
+++ b/test/refactor_nrepl/core_test.clj
@@ -3,12 +3,10 @@
             [refactor-nrepl.config :as config]
             [refactor-nrepl.core :refer [ignore-dir-on-classpath?]]))
 
-
 (defmacro assert-ignored-paths
   [paths pred]
   `(doseq [p# ~paths]
      (is (~pred (ignore-dir-on-classpath? p#)))))
-
 
 (deftest test-ignore-dir-on-classpath?
   (let [not-ignored ["/home/user/project/test"

--- a/test/refactor_nrepl/ns/clean_ns_test.clj
+++ b/test/refactor_nrepl/ns/clean_ns_test.clj
@@ -94,7 +94,7 @@
 (deftest throws-on-malformed-ns
   (is (thrown? IllegalStateException
                (core/read-ns-form-with-meta (.getAbsolutePath
-                                   (File. "test/resources/clojars-artifacts.edn"))))))
+                                             (File. "test/resources/clojars-artifacts.edn"))))))
 
 (deftest preserves-other-elements
   (let [actual (clean-ns ns1)

--- a/test/refactor_nrepl/rename_file_or_dir_test.clj
+++ b/test/refactor_nrepl/rename_file_or_dir_test.clj
@@ -146,8 +146,9 @@
       (is (some #(.endsWith % "non_clj_file") @files))
       (is (= 4 (count (filter #(.endsWith % ".cljs") @files)))))))
 
-
+
 ;;; cljs
+
 
 (def from-file-path-cljs (.getAbsolutePath (File. "test/resources/testproject/src/com/move/ns_to_be_moved_cljs.cljs")))
 (def to-file-path-cljs (.getAbsolutePath (File. "test/resources/testproject/src/com/move/moved_ns_cljs.cljs")))

--- a/test/refactor_nrepl/s_expressions_test.clj
+++ b/test/refactor_nrepl/s_expressions_test.clj
@@ -29,4 +29,4 @@
   (t/is (=  "{:qux [#{more}]}" (apply sut/get-enclosing-sexp file-content map-location)))
   (t/is (=  nil (apply sut/get-enclosing-sexp weird-file-content weird-location)))
   (t/is (= nil (sut/get-first-sexp weird-file-content)))
-  (t/is (=  "#{foo bar baz}"(sut/get-first-sexp file-content-with-set))))
+  (t/is (=  "#{foo bar baz}" (sut/get-first-sexp file-content-with-set))))

--- a/test/resources/cljcns.cljc
+++ b/test/resources/cljcns.cljc
@@ -83,5 +83,4 @@
        (PushbackReader. nil))
 
      (proxy [FilenameFilter] []
-       (accept [d n] true))
-     ))
+       (accept [d n] true))))

--- a/test/resources/ns2_cleaned_meta.clj
+++ b/test/resources/ns2_cleaned_meta.clj
@@ -1,8 +1,8 @@
 (ns ^{:author "Trurl and Klapaucius", :doc "test ns with meta"}
  resources.ns2-meta
-(:require [clojure
-[edn :refer :all :rename {read rd, read-string rs}]
-[instant :refer :all]
-[pprint :refer [cl-format fresh-line get-pretty-writer]]
-[string :refer :all :rename {reverse bar, replace foo}]
-[test :refer :all]]))
+  (:require [clojure
+             [edn :refer :all :rename {read rd, read-string rs}]
+             [instant :refer :all]
+             [pprint :refer [cl-format fresh-line get-pretty-writer]]
+             [string :refer :all :rename {reverse bar, replace foo}]
+             [test :refer :all]]))

--- a/test/resources/ns2_meta.clj
+++ b/test/resources/ns2_meta.clj
@@ -7,7 +7,7 @@
 ;; ===========================================================================
 (ns ^{:author "Trurl and Klapaucius"
       :doc "test ns with meta"}
-  resources.ns2-meta
+ resources.ns2-meta
   (:require
    [clojure.pprint :refer [fresh-line]]
    [clojure.pprint :refer [get-pretty-writer]]

--- a/test/resources/testproject/src/com/example/shadowed_macro_usages.clj
+++ b/test/resources/testproject/src/com/example/shadowed_macro_usages.clj
@@ -4,6 +4,6 @@
 (defn shadow-macro-in-fn-param [my-macro]
   (my-macro :shadowed-by-function-param))
 
-(defn shadow-macro-in-let[my-macro]
+(defn shadow-macro-in-let [my-macro]
   (let [my-macro (fn not-a-macro [])]
     (my-macro :shadowed-by-let)))


### PR DESCRIPTION
Uses the same config as `cider-nrepl`. Also runs cljfmt to fix things that came up.

Splitting the commits to 1) adding the profile/CI job, and 2) actually fixing the formatting.