### PR TITLE
Upgrade mranderson to 0.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-.PHONY: source-deps test release deploy clean
+.PHONY: inline-deps test release deploy clean
 
 VERSION ?= 1.10
 
-.source-deps:
-	lein source-deps
-	touch .source-deps
+.inline-deps:
+	lein inline-deps
+	touch .inline-deps
 
-source-deps: .source-deps
+inline-deps: .inline-deps
 
-test: .source-deps
+test: .inline-deps
 	lein with-profile +$(VERSION),+plugin.mranderson/config test
 
 cljfmt:
@@ -32,4 +32,4 @@ deploy:
 
 clean:
 	lein clean
-	rm -f .source-deps
+	rm -f .inline-deps

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ contains among other things a full stacktrace.
 
 To work with `mranderson` the first thing to do is:
 
-`lein do clean, source-deps :prefix-exclusions "[\"classlojure\"]"`
+`lein do clean, inline-deps`
 
 this creates the munged local dependencies in target/srcdeps directory
 
@@ -348,6 +348,8 @@ Or alternatively run
 `./build.sh deploy clojars`
 
 build.sh cleans, runs source-deps with the right parameters, runs the tests and then runs the provided lein target.
+
+You can also use a Makefile now: `make clean && make test` for example.
 
 ## Changelog
 

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ function check_result {
     fi
 }
 
-lein do clean, source-deps :prefix-exclusions "[\"classlojure\"]"
+lein do clean, inline-deps
 check_result
 lein with-profile +plugin.mranderson/config test
 check_result

--- a/project.clj
+++ b/project.clj
@@ -7,14 +7,10 @@
                  ^:source-dep [http-kit "2.3.0"]
                  ^:source-dep [cheshire "5.8.0"]
                  ^:source-dep [org.clojure/tools.analyzer.jvm "0.7.1"]
-                 ^:source-dep [org.clojure/tools.namespace "0.3.0-alpha3"]
-                 ;; Not used directly in refactor-nrepl, but needed because of tool.namespace
-                 ;; and the way MrAnderson processes dependencies
-                 ;; See https://github.com/clojure-emacs/cider/issues/2176 for details
-                 ^:source-dep [org.clojure/java.classpath "0.2.3"]
+                 ^:source-dep [org.clojure/tools.namespace "0.3.0-alpha3" :exclusions [org.clojure/tools.reader]]
                  ^:source-dep [org.clojure/tools.reader "1.1.1"]
                  ^:source-dep [cider/orchard "0.3.0"]
-                 ^:source-dep [lein-cljfmt "0.3.0"]
+                 ^:source-dep [cljfmt "0.6.3"]
                  ^:source-dep [me.raynes/fs "1.4.6"]
                  ^:source-dep [rewrite-clj "0.6.0"]
                  ^:source-dep [cljs-tooling "0.2.0"]
@@ -23,7 +19,10 @@
                                     :username :env/clojars_username
                                     :password :env/clojars_password
                                     :sign-releases false}]]
-  :plugins [[thomasa/mranderson "0.4.8"]]
+  :plugins [[thomasa/mranderson "0.5.0"]]
+  :mranderson {:project-prefix  "refactor.inlined-deps"
+               :expositions     [[org.clojure/tools.analyzer.jvm org.clojure/tools.analyzer]]
+               :unresolved-tree false}
   :filespecs [{:type :bytes :path "refactor-nrepl/refactor-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
   :profiles {:provided {:dependencies [[cider/cider-nrepl "0.18.0"]
                                        [org.clojure/clojure "1.8.0"]]}
@@ -38,7 +37,7 @@
              :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]
                                    [org.clojure/clojurescript "1.10.63"]]}
              :dev {:plugins [[jonase/eastwood "0.2.0"]]
-                   :global-vars {*warn-on-reflection* true}
+                   ;:global-vars {*warn-on-reflection* true}
                    :dependencies [[org.clojure/clojurescript "1.9.89"]
                                   [cider/piggieback "0.3.8"]
                                   [leiningen-core "2.7.1"]


### PR DESCRIPTION
mranderson 0.5.x specific config added to the project file as
well. Using resolved tree mode. This means that
mranderson works with a resolved dependency tree and does not create a
deeply nested directory structure, only adds prefixes to all
dependencies. Handles all depedendencies as first level ones and
processes them in a topological order.

Add project prefix in the project file and other config for unresolved
tree mode in case we want to switch to that in the near future

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

