### PR TITLE
Parallelise `refactor-nrepl.find.find-symbol/find-global-symbol`

### DIFF
--- a/src/refactor_nrepl/find/find_symbol.clj
+++ b/src/refactor_nrepl/find/find_symbol.clj
@@ -140,7 +140,7 @@
          (find-util/distribute-evenly-by {:n (find-util/processor-count)
                                           :f (fn [^File file]
                                                (-> file .length))})
-         (find-util/divide-by (find-util/processor-count))
+         (find-util/slice (find-util/processor-count))
          (pmap (fn [work]
                  (->> work
                       (mapcat (comp doall

--- a/src/refactor_nrepl/find/find_symbol.clj
+++ b/src/refactor_nrepl/find/find_symbol.clj
@@ -140,13 +140,12 @@
          (shuffle) ;; make it less likely that work will be concentrated in one partition (see next line)
          (find-util/divide-by (find-util/processor-count))
          (pmap (fn [work]
-                 ;; `vec` ensures all work is actually performed within the surrounding `pmap`
                  (->> work
-                      (mapcat (comp vec
+                      (mapcat (comp doall
                                     (partial find-symbol-in-file fully-qualified-name ignore-errors)))
-                      vec)))
+                      doall)))
          (apply concat)
-         (vec))))
+         (doall))))
 
 (defn- get&read-enclosing-sexps
   [file-content {:keys [^long line-beg ^long col-beg]}]

--- a/src/refactor_nrepl/find/find_symbol.clj
+++ b/src/refactor_nrepl/find/find_symbol.clj
@@ -137,7 +137,9 @@
                                (str/join "/" [namespace var-name]))]
     (->> (core/dirs-on-classpath)
          (mapcat (partial core/find-in-dir (some-fn core/clj-file? core/cljc-file?)))
-         (shuffle) ;; make it less likely that work will be concentrated in one partition (see next line)
+         (find-util/distribute-evenly-by {:n (find-util/processor-count)
+                                          :f (fn [^File file]
+                                               (-> file .length))})
          (find-util/divide-by (find-util/processor-count))
          (pmap (fn [work]
                  (->> work

--- a/src/refactor_nrepl/find/util.clj
+++ b/src/refactor_nrepl/find/util.clj
@@ -27,5 +27,28 @@
   (let [c (/ (count coll) n)]
     (partition-all c coll)))
 
+(defn distribute-evenly-by
+  "Sorts `coll` by `f` in such a way that if partitioned by `n`, each partition will have items of similar cost."
+  [{:keys [f n]
+    :as   options}
+   coll]
+  {:pre [(partial every? #{:f :n}) (keys options)
+         (ifn? f)
+         (pos? n)
+         (integer? n)
+         (coll? coll)]}
+  (if-not (seq coll)
+    coll
+    (->> coll
+         (sort-by f)
+         (partition-all n)
+         (map (fn [chunk]
+                (->> (repeat ::padding)
+                     (concat chunk)
+                     (take n))))
+         (apply map vector)
+         (apply concat)
+         (remove #{::padding}))))
+
 (defn processor-count []
   (-> (Runtime/getRuntime) .availableProcessors))

--- a/src/refactor_nrepl/find/util.clj
+++ b/src/refactor_nrepl/find/util.clj
@@ -20,3 +20,12 @@
              (core/suffix name)))))
   ([file occ]
    (spurious? (assoc occ :file file))))
+
+(defn divide-by
+  "Divides `coll` in `n` parts. The parts can have disparate sizes if the division isn't exact."
+  [n coll]
+  (let [c (/ (count coll) n)]
+    (partition-all c coll)))
+
+(defn processor-count []
+  (-> (Runtime/getRuntime) .availableProcessors))

--- a/src/refactor_nrepl/find/util.clj
+++ b/src/refactor_nrepl/find/util.clj
@@ -21,7 +21,7 @@
   ([file occ]
    (spurious? (assoc occ :file file))))
 
-(defn divide-by
+(defn slice
   "Divides `coll` in `n` parts. The parts can have disparate sizes if the division isn't exact."
   [n coll]
   (let [c (/ (count coll) n)]

--- a/test/refactor_nrepl/find/util_test.clj
+++ b/test/refactor_nrepl/find/util_test.clj
@@ -1,0 +1,21 @@
+(ns refactor-nrepl.find.util-test
+  (:require [clojure.test :refer :all]
+            [refactor-nrepl.find.util :as sut]))
+
+(deftest divide-by
+  (are [input n expected] (= expected
+                             (sut/divide-by n input))
+    []      1 '()
+    [1]     1 '((1))
+    [1 1]   1 '((1 1))
+    [1 1 1] 1 '((1 1 1))
+
+    []      2 '()
+    [1]     2 '((1))
+    [1 1]   2 '((1) (1))
+    [1 1 1] 2 '((1 1) (1))
+
+    []      3 '()
+    [1]     3 '((1))
+    [1 1]   3 '((1) (1))
+    [1 1 1] 3 '((1) (1) (1))))

--- a/test/refactor_nrepl/find/util_test.clj
+++ b/test/refactor_nrepl/find/util_test.clj
@@ -19,3 +19,51 @@
     [1]     3 '((1))
     [1 1]   3 '((1) (1))
     [1 1 1] 3 '((1) (1) (1))))
+
+(deftest distribute-evenly-by
+  (testing "Basic behavior"
+    (are [i n e] (= e
+                    (sut/distribute-evenly-by {:n n
+                                               :f identity}
+                                              i))
+
+      []                                1 []
+      []                                2 []
+
+      [1 1 2 2]                         1 [1 1 2 2]
+      [1 1 2 2]                         2 [1 2, 1 2]
+      [1 1 2 2]                         4 [1, 1, 2, 2]
+
+      [1 1 1 1 2 2 2 2 3 3 3 3 4 4 4 4] 1 [1 1 1 1 2 2 2 2 3 3 3 3 4 4 4 4]
+      [1 1 1 1 2 2 2 2 3 3 3 3 4 4 4 4] 2 [1 1 2 2 3 3 4 4, 1 1 2 2 3 3 4 4]
+      [1 1 1 1 2 2 2 2 3 3 3 3 4 4 4 4] 4 [1 2 3 4, 1 2 3 4, 1 2 3 4, 1 2 3 4]
+
+      [1 1 1 2 2 2 3 3 3]               3 '[1 2 3, 1 2 3, 1 2 3]))
+
+  (testing "No items are ever lost or modified: they are only sorted"
+    (doseq [input-index (range 100)
+            n (range 1 101)
+            :let [input (range input-index)
+                  output (sut/distribute-evenly-by {:n n
+                                                    :f identity}
+                                                   input)]]
+      (is (= (->> output sort)
+             input)))))
+
+(deftest workload-partitioning
+  (testing "`distribute-evenly-by` works well in conjunction with `divide-by`"
+    (are [input n expected] (= expected
+                               (->> input
+                                    (sut/distribute-evenly-by {:n n
+                                                               :f identity})
+                                    (sut/divide-by n)))
+      []                                4 []
+      [1 1 1 1 2 2 2 2 3 3 3 3 4 4 4 4] 4 '[(1 2 3 4) (1 2 3 4) (1 2 3 4) (1 2 3 4)])
+
+    (doseq [_ (range 100)]
+      (= '[(1 2 3 4) (1 2 3 4) (1 2 3 4) (1 2 3 4)]
+         (->> [1 1 1 1 2 2 2 2 3 3 3 3 4 4 4 4]
+              (shuffle)
+              (sut/distribute-evenly-by {:n 4
+                                         :f identity})
+              (sut/divide-by 4))))))

--- a/test/refactor_nrepl/find/util_test.clj
+++ b/test/refactor_nrepl/find/util_test.clj
@@ -2,9 +2,9 @@
   (:require [clojure.test :refer :all]
             [refactor-nrepl.find.util :as sut]))
 
-(deftest divide-by
+(deftest slice
   (are [input n expected] (= expected
-                             (sut/divide-by n input))
+                             (sut/slice n input))
     []      1 '()
     [1]     1 '((1))
     [1 1]   1 '((1 1))
@@ -51,12 +51,12 @@
              input)))))
 
 (deftest workload-partitioning
-  (testing "`distribute-evenly-by` works well in conjunction with `divide-by`"
+  (testing "`distribute-evenly-by` works well in conjunction with `slice`"
     (are [input n expected] (= expected
                                (->> input
                                     (sut/distribute-evenly-by {:n n
                                                                :f identity})
-                                    (sut/divide-by n)))
+                                    (sut/slice n)))
       []                                4 []
       [1 1 1 1 2 2 2 2 3 3 3 3 4 4 4 4] 4 '[(1 2 3 4) (1 2 3 4) (1 2 3 4) (1 2 3 4)])
 
@@ -66,4 +66,4 @@
               (shuffle)
               (sut/distribute-evenly-by {:n 4
                                          :f identity})
-              (sut/divide-by 4))))))
+              (sut/slice 4))))))


### PR DESCRIPTION
(Second attempt after the failed https://github.com/clojure-emacs/refactor-nrepl/pull/246 )

## What

`refactor-nrepl.find.find-symbol/find-symbol-in-file` is an expensive op, particularly because it can trigger an AST analysis for a given ns.

That, combined with the large workload of analysing [all](https://github.com/clojure-emacs/refactor-nrepl/blob/bb27d1345cc564aa8f3b5ecad7c0560f221a3e0b/src/refactor_nrepl/find/find_symbol.clj#L138) files within a given project seems to justify parallelization.

## Benchmarks

Applying [this patch](https://gist.github.com/vemv/300582528b1839e450d68160c1e865cf) to my branch will add a poor man's benchmark. With it, each clj-refactor.el `rs` will use map or pmap intermittently, and log the time:

<img width="1274" alt="Screenshot 2019-03-28 at 14 47 13" src="https://user-images.githubusercontent.com/1162994/55165063-06dde000-516d-11e9-9bfe-00eec43ef576.png">

(the screenshot was taken after multiple 'warmup' runs)

---

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [ ] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
  * build.sh fails for me even on latest `master`
  * But the changes there are quite unlikely to be build-breaking.
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
  * (Impl detail)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
  * (Impl detail)