### PR TITLE
Updating the deps as far as we can without breaking tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ install.cmd
 /.cljs_node_repl/
 /out/
 /.lein-env
+.inline-deps

--- a/project.clj
+++ b/project.clj
@@ -3,16 +3,16 @@
   :url "http://github.com/clojure-emacs/refactor-nrepl"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[nrepl "0.4.4"]
+  :dependencies [[nrepl "0.5.3"]
                  ^:inline-dep [http-kit "2.3.0"]
-                 ^:inline-dep [cheshire "5.8.0"]
-                 ^:inline-dep [org.clojure/tools.analyzer.jvm "0.7.1"]
+                 ^:inline-dep [cheshire "5.8.1"]
+                 ^:inline-dep [org.clojure/tools.analyzer.jvm "0.7.2"]
                  ^:inline-dep [org.clojure/tools.namespace "0.3.0-alpha3" :exclusions [org.clojure/tools.reader]]
-                 ^:inline-dep [org.clojure/tools.reader "1.1.1"]
-                 ^:inline-dep [cider/orchard "0.3.0"]
-                 ^:inline-dep [cljfmt "0.6.3"]
-                 ^:inline-dep [me.raynes/fs "1.4.6"]
-                 ^:inline-dep [rewrite-clj "0.6.0"]
+                 ^:inline-dep [org.clojure/tools.reader "1.3.2"]
+                 ^:inline-dep [cider/orchard "0.4.0"]
+                 ^:inline-dep [cljfmt "0.6.4"]
+                 ^:inline-dep [clj-commons/fs "1.5.0"]
+                 ^:inline-dep [rewrite-clj "0.6.1"]
                  ^:inline-dep [cljs-tooling "0.2.0"]
                  ^:inline-dep [version-clj "0.1.2"]]
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
@@ -24,7 +24,7 @@
                :expositions     [[org.clojure/tools.analyzer.jvm org.clojure/tools.analyzer]]
                :unresolved-tree false}
   :filespecs [{:type :bytes :path "refactor-nrepl/refactor-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
-  :profiles {:provided {:dependencies [[cider/cider-nrepl "0.18.0"]
+  :profiles {:provided {:dependencies [[cider/cider-nrepl "0.20.0"]
                                        [org.clojure/clojure "1.8.0"]]}
              :test {:dependencies [[print-foo "1.0.2"]]
                     :src-paths ["test/resources"]}
@@ -32,15 +32,15 @@
                                   [org.clojure/clojurescript "1.8.51"]
                                   [javax.xml.bind/jaxb-api "2.3.1"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]
-                                  [org.clojure/clojurescript "1.9.908"]
+                                  [org.clojure/clojurescript "1.9.946"]
                                   [javax.xml.bind/jaxb-api "2.3.1"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]
-                                   [org.clojure/clojurescript "1.10.63"]]}
+                                   [org.clojure/clojurescript "1.10.520"]]}
              :dev {:plugins [[jonase/eastwood "0.2.0"]]
                    :global-vars {*warn-on-reflection* true}
-                   :dependencies [[org.clojure/clojurescript "1.9.89"]
-                                  [cider/piggieback "0.3.8"]
-                                  [leiningen-core "2.7.1"]
+                   :dependencies [[org.clojure/clojurescript "1.9.946"]
+                                  [cider/piggieback "0.4.0"]
+                                  [leiningen-core "2.9.0"]
                                   [commons-io/commons-io "2.6"]]
                    :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}
                    :java-source-paths ["test/java"]


### PR DESCRIPTION
Hoping this is useful. I've updated the deps as far as possible without breaking tests. Of what remain:

- `cider-nrepl` 0.21 requires `nrepl` 0.6. Moving to these two broke some tests. This might be something to do with the new printing middleware.
- `cljs-tooling` 0.3 changed the varity of a function, as part of its self-hosted cljs change. This looks fixable.

---

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
