### PR TITLE
Fix when `get-enclosing-sexp` sometimes selects a non enclosing sexp

### DIFF
--- a/test/refactor_nrepl/s_expressions_test.clj
+++ b/test/refactor_nrepl/s_expressions_test.clj
@@ -11,11 +11,11 @@
   ;; some other stuff
   (foobar baz)")
 (def binding-location [3 8])
-(def funcall-location [6 8])
 (def set-location [7 35])
 (def map-location [7 28])
 (def weird-location [1 5])
 (def println-location [5 8])
+(def when-not-location [10 9])
 
 (t/deftest get-enclosing-sexp-test
   (t/is (= "[some :bindings
@@ -28,5 +28,8 @@
   (t/is (=  "#{more}" (apply sut/get-enclosing-sexp file-content set-location)))
   (t/is (=  "{:qux [#{more}]}" (apply sut/get-enclosing-sexp file-content map-location)))
   (t/is (=  nil (apply sut/get-enclosing-sexp weird-file-content weird-location)))
+  (t/is (= "(when-not (= true true)
+    (= 5 (* 2 2)))"
+           (apply sut/get-enclosing-sexp file-content when-not-location)))
   (t/is (= nil (sut/get-first-sexp weird-file-content)))
   (t/is (=  "#{foo bar baz}" (sut/get-first-sexp file-content-with-set))))

--- a/test/resources/testproject/src/com/example/sexp_test.clj
+++ b/test/resources/testproject/src/com/example/sexp_test.clj
@@ -6,3 +6,7 @@
     (println #{some}
              ;; unhelpful comment )
              (prn {"foo" {:qux [#{more}]}}))))
+
+(defn bar []
+  (when-not (= true true)
+    (= 5 (* 2 2))))


### PR DESCRIPTION
Stumbled upon this bug when working on the POC on the `support-cljs` branch. As I spent long minutes staring at this and counting lines/columns on my fingers I thought better to create a PR and invite a review than just pushing it ;)

The added test in `s-expressions-test` proves the bug. It fails with the previous implementation because although `=` is closer to the point than the actual enclosing sexp it does not enclose the point. The trace for this failure:

```
best (ns resources.testproject.src.com.example.sexp-test) distance 11133 zloc (ns resources.testproject.src.com.example.sexp-test) distance 11133
best (ns resources.testproject.src.com.example.sexp-test) distance 11133 zloc ns distance 11086
best ns distance 11086 zloc resources.testproject.src.com.example.sexp-test distance 11092
best ns distance 11086 zloc (defn foo [] (let [some :bindings more :bindings] (println #{some} (prn {foo {:qux [#{more}]}})))) distance 8427
best (defn foo [] (let [some :bindings more :bindings] (println #{some} (prn {foo {:qux [#{more}]}})))) distance 8427 zloc defn distance 8884
best (defn foo [] (let [some :bindings more :bindings] (println #{some} (prn {foo {:qux [#{more}]}})))) distance 8427 zloc foo distance 8830
best (defn foo [] (let [some :bindings more :bindings] (println #{some} (prn {foo {:qux [#{more}]}})))) distance 8427 zloc [] distance 8813
best (defn foo [] (let [some :bindings more :bindings] (println #{some} (prn {foo {:qux [#{more}]}})))) distance 8427 zloc (let [some :bindings more :bindings] (println #{some} (prn {foo {:qux [#{more}]}}))) distance 7406
best (let [some :bindings more :bindings] (println #{some} (prn {foo {:qux [#{more}]}}))) distance 7406 zloc let distance 7763
best (let [some :bindings more :bindings] (println #{some} (prn {foo {:qux [#{more}]}}))) distance 7406 zloc [some :bindings more :bindings] distance 7634
best (let [some :bindings more :bindings] (println #{some} (prn {foo {:qux [#{more}]}}))) distance 7406 zloc some distance 7713
best (let [some :bindings more :bindings] (println #{some} (prn {foo {:qux [#{more}]}}))) distance 7406 zloc :bindings distance 7753
best (let [some :bindings more :bindings] (println #{some} (prn {foo {:qux [#{more}]}}))) distance 7406 zloc more distance 6613
best more distance 6613 zloc :bindings distance 6653
best more distance 6613 zloc (println #{some} (prn {foo {:qux [#{more}]}})) distance 5385
best (println #{some} (prn {foo {:qux [#{more}]}})) distance 5385 zloc println distance 5543
best (println #{some} (prn {foo {:qux [#{more}]}})) distance 5385 zloc #{some} distance 5551
best (println #{some} (prn {foo {:qux [#{more}]}})) distance 5385 zloc some distance 5570
best (println #{some} (prn {foo {:qux [#{more}]}})) distance 5385 zloc (prn {foo {:qux [#{more}]}}) distance 3374
best (prn {foo {:qux [#{more}]}}) distance 3374 zloc prn distance 3358
best prn distance 3358 zloc {foo {:qux [#{more}]}} distance 3423
best prn distance 3358 zloc foo distance 3415
best prn distance 3358 zloc {:qux [#{more}]} distance 3492
best prn distance 3358 zloc :qux distance 3491
best prn distance 3358 zloc [#{more}] distance 3551
best prn distance 3358 zloc #{more} distance 3560
best prn distance 3358 zloc more distance 3579
best prn distance 3358 zloc (defn bar [] (when-not (= true true) (= 5 (* 2 2)))) distance 1200
best (defn bar [] (when-not (= true true) (= 5 (* 2 2)))) distance 1200 zloc defn distance 1184
best defn distance 1184 zloc bar distance 1130
best bar distance 1130 zloc [] distance 1113
best [] distance 1113 zloc (when-not (= true true) (= 5 (* 2 2))) distance 179
best (when-not (= true true) (= 5 (* 2 2))) distance 179 zloc when-not distance 62
best when-not distance 62 zloc (= true true) distance 46
best (= true true) distance 46 zloc = distance 45
best = distance 45 zloc true distance 70
best = distance 45 zloc true distance 125
best = distance 45 zloc (= 5 (* 2 2)) distance 1158
best = distance 45 zloc = distance 1143
best = distance 45 zloc 5 distance 1121
best = distance 45 zloc (* 2 2) distance 1107
best = distance 45 zloc * distance 1112
best = distance 45 zloc 2 distance 1134
best = distance 45 zloc 2 distance 1156
```

Have not added anything to the CHANGELOG as I don't think this bug managed to cause any harm in when `get-enclosing-sexp` was used -- at least not in `find-used-locals`.


- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)


