### PR TITLE
clean-ns: fall back to :relative-path, when given

### DIFF
--- a/src/refactor_nrepl/ns/clean_ns.clj
+++ b/src/refactor_nrepl/ns/clean_ns.clj
@@ -37,9 +37,10 @@
   ns-form)
 
 (defn clean-ns [{:keys [path relative-path]}]
-  {:pre [(seq path) (string? path) (core/source-file? path)]}
+  {:pre [(seq path) (string? path)]}
   ;; Try first the absolute, then the relative path
   (let [path (first (filter #(some-> % io/file .exists) [path relative-path]))]
+    (assert (core/source-file? path))
     ;; Prefix notation not supported in cljs.
     ;; We also turn it off for cljc for reasons of symmetry
     (config/with-config {:prefix-rewriting (if (or (core/cljs-file? path)

--- a/src/refactor_nrepl/ns/pprint.clj
+++ b/src/refactor_nrepl/ns/pprint.clj
@@ -156,6 +156,6 @@
                       (form-is? form :import) (pprint-import-form form)
                       :else (pprint form))))
             forms)))
-        (.replaceAll "\r" "")
+        (str/replace "\r" "")
         fmt/reformat-string
-        (.replaceAll (Pattern/quote "#? @") "#?@"))))
+        (str/replace (Pattern/quote "#? @") "#?@"))))

--- a/test/refactor_nrepl/ns/clean_ns_test.clj
+++ b/test/refactor_nrepl/ns/clean_ns_test.clj
@@ -3,7 +3,8 @@
             [refactor-nrepl.config :as config]
             [refactor-nrepl.core :as core]
             [refactor-nrepl.ns.clean-ns :refer [clean-ns]]
-            [refactor-nrepl.ns.pprint :refer [pprint-ns]])
+            [refactor-nrepl.ns.pprint :refer [pprint-ns]]
+            [clojure.string :as str])
   (:import java.io.File))
 
 (defn- absolute-path [^String path]
@@ -49,7 +50,7 @@
 
 (def ns-using-dollar (clean-msg "test/resources/ns_using_dollar.clj"))
 
-(def ns1-relative-path {:path "I do not exist"
+(def ns1-relative-path {:path "I do not exist.clj"
                         :relative-path "test/resources/ns1.clj"})
 
 (deftest combines-requires
@@ -59,7 +60,7 @@
 
 (deftest meta-preserved
   (let [cleaned (pprint-ns (clean-ns ns2-meta))]
-    (is (.contains cleaned "^{:author \"Trurl and Klapaucius\"
+    (is (str/includes? cleaned "^{:author \"Trurl and Klapaucius\"
       :doc \"test ns with meta\"}"))))
 
 (deftest rewrites-use-to-require

--- a/test/refactor_nrepl/ns/clean_ns_test.clj
+++ b/test/refactor_nrepl/ns/clean_ns_test.clj
@@ -10,7 +10,8 @@
   (.getAbsolutePath (File. path)))
 
 (defn- clean-msg [path]
-  {:path (absolute-path path)})
+  {:path (absolute-path path)
+   :relative-path path})
 
 (def ns1 (clean-msg "test/resources/ns1.clj"))
 (def ns1-cleaned (core/read-ns-form-with-meta (absolute-path "test/resources/ns1_cleaned.clj")))
@@ -47,6 +48,9 @@
 (def ns-with-inner-classes (clean-msg "test/resources/ns_with_inner_classes.clj"))
 
 (def ns-using-dollar (clean-msg "test/resources/ns_using_dollar.clj"))
+
+(def ns1-relative-path {:path "I do not exist"
+                        :relative-path "test/resources/ns1.clj"})
 
 (deftest combines-requires
   (let [requires (core/get-ns-component (clean-ns ns2) :require)
@@ -224,3 +228,7 @@
 (deftest does-not-break-import-for-inner-class
   (let [cleaned (pprint-ns (clean-ns ns-with-inner-classes))]
     (is (re-find #":import.*Line2D\$Double" cleaned))))
+
+(deftest fallback-to-relative-path
+  (is (= (pprint-ns (clean-ns ns1))
+         (pprint-ns (clean-ns ns1-relative-path)))))


### PR DESCRIPTION
Allow the client to send both the absolute path and a relative path to a file,
we use the first one that we can find.

The absolute path is used when the client (Emacs) and the JVM are on the same
filesystem/same machine. The second is used when they are not on the same
filesystem (e.g. running nREPL on a remote machine or in a VM), but the JVM runs
in the (mounted) project directory, so that relative file lookups still work.

I failed to run the tests locally. Will see what CI says.

See https://github.com/clojure-emacs/clj-refactor.el/issues/380#issuecomment-484509768
