### PR TITLE
Add try/catch when reading EDN data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * [#251](https://github.com/clojure-emacs/refactor-nrepl/pull/251) `clean-ns` support extra message key `relative-path`, which will be used if `path` does not exist.
+* [#256](https://github.com/clojure-emacs/refactor-nrepl/pull/256) ignore malformed artifact coordinates when fetching from Clojars.
 
 ## 2.4.0
 

--- a/src/refactor_nrepl/artifacts.clj
+++ b/src/refactor_nrepl/artifacts.clj
@@ -39,7 +39,11 @@
          java.net.URL.
          io/reader
          line-seq
-         (map edn/read-string))
+         (keep #(try
+                  (edn/read-string %)
+                  (catch Exception _
+                    ;; Ignore artifact if not readable. See #255
+                    nil))))
     (catch Exception _
       ;; In the event clojars is down just return an empty vector. See #136.
       [])))

--- a/src/refactor_nrepl/artifacts.clj
+++ b/src/refactor_nrepl/artifacts.clj
@@ -31,6 +31,14 @@
         (neg? (- millis-per-day (- (.getTime (java.util.Date.)) last-modified)))
         true)))
 
+(defn- edn-read-or-nil
+  "Read a form `s`. Return nil if it cannot be parsed."
+  [s]
+  (try (edn/read-string s)
+       (catch Exception _
+         ;; Ignore artifact if not readable. See #255
+         nil)))
+
 (defn get-clojars-artifacts!
   "Returns a vector of [[some/lib \"0.1\"]...]."
   []
@@ -39,11 +47,7 @@
          java.net.URL.
          io/reader
          line-seq
-         (keep #(try
-                  (edn/read-string %)
-                  (catch Exception _
-                    ;; Ignore artifact if not readable. See #255
-                    nil))))
+         (keep edn-read-or-nil))
     (catch Exception _
       ;; In the event clojars is down just return an empty vector. See #136.
       [])))

--- a/test/refactor_nrepl/artifacts_test.clj
+++ b/test/refactor_nrepl/artifacts_test.clj
@@ -46,3 +46,10 @@
       (reset! artifacts/artifacts {"org.clojure/clojure" clojure-versions})
       (is (= sorted-clojure-versions
              (artifacts/artifact-versions {:artifact "org.clojure/clojure"}))))))
+
+(deftest ignores-invalid-artifact-forms
+  (let [bad-form "[bad/1.1 \"funky\"]"
+        good-form "[foo/bar \"1.1\"]"]
+    (is (nil? (#'artifacts/edn-read-or-nil bad-form)))
+    (is (= 'foo/bar (first (#'artifacts/edn-read-or-nil good-form))))
+    (is (= "1.1" (second (#'artifacts/edn-read-or-nil good-form))))))


### PR DESCRIPTION
Fixes #255 

Since the `artifacts/get-clojars-artifacts!` function is written in a way that isn't easily testable I opted out on tests. I would need to refactor the code a bit more to make it possible to write a test for this. Let me know if you'd like me to do that.

The fix is simply to use `keep` instead of `map` - and swallow any exception on `edn/read-string`.
