### PR TITLE
Support shadow-cljs style requires

### DIFF
--- a/src/refactor_nrepl/ns/libspecs.clj
+++ b/src/refactor_nrepl/ns/libspecs.clj
@@ -16,7 +16,7 @@
 (defn- aliases-by-frequencies [libspecs]
   (->> libspecs
        (mapcat aliases) ; => [[str clojure.string] ...]
-       (sort-by second)
+       (sort-by #(-> % second str)) ; because shadow-cljs has string namespaces
        (group-by first) ; => {str [[str clojure.string] [str clojure.string]] ...}
        (map (comp seq frequencies second)) ; => (([[set clojure.set] 4] [set set] 1) ...)
        (map (partial sort-by second >)) ; by decreasing frequency


### PR DESCRIPTION
Shadow-cljs supports strings in the `:require` declaration (i.e. `["rangy-updated" :as rangy]`). This breaks cljr-slash because `aliases-by-frequencies ` ends up trying to compare strings with symbols.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (run `lein do clean, test`)
- [ ] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
