### PR TITLE
Support inline whitelisting for :require/:imports used for side-effects

### DIFF
--- a/src/refactor_nrepl/ns/prune_dependencies.clj
+++ b/src/refactor_nrepl/ns/prune_dependencies.clj
@@ -87,6 +87,7 @@
 (defn- class-in-use?
   [symbols-in-file c]
   (or
+   (:side-effects (meta c))
    ;; fully.qualified.Class
    (symbols-in-file c)
    ;; OnlyClassName, Class$Enum/Value or Class$Innerclass$InnerInnerClass
@@ -116,10 +117,11 @@
 ;; are side-effecting at load but might look unused and otherwise be
 ;; pruned.
 (defn- libspec-should-never-be-pruned? [libspec]
-  (let [ns-name (str (:ns libspec))]
-    (some (fn [^String pattern]
-            (re-find (re-pattern pattern) ns-name))
-          (:libspec-whitelist config/*config*))))
+  (or (:side-effects (meta (:ns libspec)))
+      (let [ns-name (str (:ns libspec))]
+        (some (fn [^String pattern]
+                (re-find (re-pattern pattern) ns-name))
+              (:libspec-whitelist config/*config*)))))
 
 (defn- prune-libspec [symbols-in-file current-ns libspec]
   (if (libspec-should-never-be-pruned? libspec)

--- a/test/refactor_nrepl/ns/clean_ns_test.clj
+++ b/test/refactor_nrepl/ns/clean_ns_test.clj
@@ -25,6 +25,8 @@
 (def ns-with-rename (clean-msg "test/resources/ns_with_rename.clj"))
 (def ns-with-rename-cleaned (core/read-ns-form-with-meta "test/resources/ns_with_rename_cleaned.clj"))
 (def ns-with-unused-deps (clean-msg "test/resources/unused_deps.clj"))
+(def ns-with-whitelisted-deps (clean-msg "test/resources/ns_with_whitelisted_deps.clj"))
+(def ns-with-whitelisted-deps-cleaned (core/read-ns-form-with-meta "test/resources/ns_with_whitelisted_deps_cleaned.clj"))
 (def ns-without-unused-deps (core/read-ns-form-with-meta
                              (absolute-path "test/resources/unused_removed.clj")))
 (def cljs-file (clean-msg "test/resources/file.cljs"))
@@ -140,6 +142,14 @@
         clean-imports (core/get-ns-component ns-without-unused-deps :import)]
     (is (= clean-requires requires))
     (is (= clean-imports imports))))
+
+(deftest allows-unused-dependencies-with-whitelist-metadata
+  (let [expected ns-with-whitelisted-deps-cleaned
+        actual  (clean-ns ns-with-whitelisted-deps)]
+    (is (= (core/get-ns-component expected :require)
+           (core/get-ns-component actual :require)))
+    (is (= (core/get-ns-component expected :import)
+           (core/get-ns-component actual :import)))))
 
 (def artifact-ns '(ns refactor-nrepl.artifacts
                     (:require [clojure

--- a/test/resources/ns_with_whitelisted_deps.clj
+++ b/test/resources/ns_with_whitelisted_deps.clj
@@ -1,0 +1,16 @@
+(ns resources.ns-with-whitelisted-deps
+  (:require [^:side-effects clojure.set :as set]
+            ^:side-effects [clojure.string :as str]
+            ^:side-effects clojure.pprint
+            [resources
+             ^:side-effects ns1
+             ^:side-effects ns2]
+            ^:side-effects
+            [clojure
+             [data :as data]
+             [walk :as walk]])
+  (:import ^:side-effects java.util.Date
+           ^:side-effects [java.io BufferedReader Reader]
+           [java.sql
+            ^:side-effects Timestamp
+            ^:side-effects Time]))

--- a/test/resources/ns_with_whitelisted_deps_cleaned.clj
+++ b/test/resources/ns_with_whitelisted_deps_cleaned.clj
@@ -1,0 +1,12 @@
+(ns resources.ns-with-whitelisted-deps
+  (:require [clojure
+             [data :as data]
+             pprint
+             [set :as set]
+             [walk :as walk]]
+            [resources
+             ns1
+             ns2])
+  (:import [java.io BufferedReader Reader]
+           [java.sql Time Timestamp]
+           java.util.Date))


### PR DESCRIPTION
Tweaks `clean-ns` so that `:require` and `:import` symbols with `^:side-effects` metadata won't be removed. This is useful for cases where want import a namespace for side effects without having `clean-ns` remove it, or for false positives (such as #239).

###### before
```clj
(ns resources.ns-with-whitelisted-deps
  (:require [^:side-effects clojure.set :as set]
            [clojure.string :as str])
  (:import java.sql.Timestamp
           ^:side-effects java.util.Date))
```

###### after calling `clean-ns`

```clj
(ns resources.ns-with-whitelisted-deps
  (:require [clojure.set :as set])
  (:import java.util.Date))
```

Setting `cljr-libspec-whitelist`, the workaround mentioned in #239, doesn't work when running outside of Emacs – for example when using this [namespace declaration linter](https://github.com/camsaul/lein-check-namespace-decls) I put together using `clean-ns`.

To make this easier to use correctly it accepts `^:side-effects` on *any* of the following:

*  the `:require`/`:import` namespace/class symbol itself, e.g. 
    ```clj
    (:require ^:side-effects clojure.string)
    ```
*  the sequence wrapping the namespace/class symbol
    ```clj
    (:require ^:side-effects [clojure.string :as str])
    ```
*  the prefix form wrapping the namespace/class symbol
    ```clj
    (:require ^:side-effects [clojure data string])
    ```
