### PR TITLE
clean-ns: group together npm deps

### DIFF
--- a/src/refactor_nrepl/ns/rebuild.clj
+++ b/src/refactor_nrepl/ns/rebuild.clj
@@ -60,7 +60,7 @@
   ^String [dep]
   (str/lower-case
    (if (sequential? dep)
-     (let [name (-> dep first name)
+     (let [name (-> dep first pr-str)
            ;; penalize prefix forms so [foo.bar :as bar]
            ;; comes before [foo.bar [qux :as qux] [quux ..]]
            suffix (if (and (> (count dep) 1) (sequential? (second dep)))

--- a/src/refactor_nrepl/ns/tracker.clj
+++ b/src/refactor_nrepl/ns/tracker.clj
@@ -1,16 +1,30 @@
 (ns refactor-nrepl.ns.tracker
-  (:require [clojure.tools.namespace
+  (:require [clojure.java.io :as io]
+            [clojure.tools.namespace
              [dependency :as dep]
              [file :as file]
              [track :as tracker]]
-            [refactor-nrepl.core :as core]))
+            [refactor-nrepl.core :as core]
+            [refactor-nrepl.ns.ns-parser :as ns-parser]))
+
+;; Exclude cljs files that use npm string requires until they fix this bug:
+;; https://clojure.atlassian.net/projects/TNS/issues/TNS-51
+(defn- safe-for-clojure-tools-namespace? [f]
+  (->> (io/file f)
+       (.getAbsolutePath)
+       ns-parser/parse-ns
+       :cljs
+       :require
+       (map :ns)
+       (not-any? string?)))
 
 (defn build-tracker
   "Build a tracker for the project.
 
   If file-predicate is provided, use that instead of `core/source-file?`"
   ([]
-   (build-tracker core/source-file?))
+   (build-tracker #(and (core/source-file? %)
+                        (safe-for-clojure-tools-namespace? %))))
   ([file-predicate]
    (file/add-files (tracker/tracker) (core/find-in-project file-predicate))))
 

--- a/test/refactor_nrepl/ns/clean_ns_test.clj
+++ b/test/refactor_nrepl/ns/clean_ns_test.clj
@@ -53,6 +53,9 @@
 (def ns1-relative-path {:path "I do not exist.clj"
                         :relative-path "test/resources/ns1.clj"})
 
+(def ns-with-npm-strs (clean-msg "test/resources/ns_with_npm_strs.cljs"))
+(def ns-with-npm-strs-clean (clean-msg "test/resources/ns_with_npm_strs_clean.cljs"))
+
 (deftest combines-requires
   (let [requires (core/get-ns-component (clean-ns ns2) :require)
         combined-requires (core/get-ns-component ns2-cleaned :require)]
@@ -233,3 +236,13 @@
 (deftest fallback-to-relative-path
   (is (= (pprint-ns (clean-ns ns1))
          (pprint-ns (clean-ns ns1-relative-path)))))
+
+;; keep quotes around string requires
+(deftest npm-string-preservation
+  (let [cleaned (pprint-ns (clean-ns ns-with-npm-strs))]
+    (is (re-find #"\[\"react-native\" :as rn\]" cleaned))))
+
+;; group string requires together when sorting
+(deftest npm-string-sorting
+  (is (= (pprint-ns (clean-ns ns-with-npm-strs))
+         (pprint-ns (read-string (slurp (:path ns-with-npm-strs-clean)))))))

--- a/test/resources/ns_with_npm_strs.cljs
+++ b/test/resources/ns_with_npm_strs.cljs
@@ -1,0 +1,14 @@
+(ns resources.ns-with-npm-strs
+  (:require ["react-native" :as rn]
+            [clojure.string :as str]
+            ["@react-native-community/async-storage" :as async-storage]
+            ["@fortawesome/react-native-fontawesome" :as fa]
+            ["@fortawesome/free-solid-svg-icons" :as fa-icons]))
+
+(defmacro black-hole [& body])
+
+(black-hole
+ rn/View
+ str/join
+ fa/FontAwesomeIcon
+ fa-icons/faCoffee)

--- a/test/resources/ns_with_npm_strs_clean.cljs
+++ b/test/resources/ns_with_npm_strs_clean.cljs
@@ -1,0 +1,5 @@
+(ns resources.ns-with-npm-strs
+  (:require ["@fortawesome/free-solid-svg-icons" :as fa-icons]
+            ["@fortawesome/react-native-fontawesome" :as fa]
+            ["react-native" :as rn]
+            [clojure.string :as str]))


### PR DESCRIPTION
This small change will have all the npm string-style requires grouped together.  I think this is desirable, as npm libraries look and act quite differently from regular clojure requires.