### PR TITLE
[Fix #275] Honor cljr-ignore-analyzer-errors flag in macros analyzer

### DIFF
--- a/src/refactor_nrepl/find/find_symbol.clj
+++ b/src/refactor_nrepl/find/find_symbol.clj
@@ -234,8 +234,9 @@
 
 (defn find-symbol [{:keys [file ns name line column ignore-errors]}]
   (core/throw-unless-clj-file file)
-  (let [macros (future (find-macro (core/fully-qualify ns name)))
-        globals (->> (find-global-symbol file ns name (= ignore-errors "true"))
+  (let [ignore-errors? (= ignore-errors "true")
+        macros (future (find-macro (core/fully-qualify ns name) ignore-errors?))
+        globals (->> (find-global-symbol file ns name ignore-errors?)
                      distinct
                      (remove find-util/spurious?)
                      future)]

--- a/test/refactor_nrepl/find/find_macros_test.clj
+++ b/test/refactor_nrepl/find/find_macros_test.clj
@@ -6,7 +6,7 @@
   (first (filter #(re-find regexp (:match %)) occurrences)))
 
 (deftest find-macro-test
-  (let [occurrences (find-macro "com.example.macro-def/my-macro")
+  (let [occurrences (find-macro "com.example.macro-def/my-macro" false)
         {:keys [line-beg col-beg file match]}
         (first (filter #(.contains (:match %) "defmacro") occurrences))]
     (testing "finds the macro definition"
@@ -29,29 +29,29 @@
       (is (.endsWith file "macro_def.clj")))))
 
 (deftest find-regular-symbol-test
-  (is (nil? (find-macro "sym"))))
+  (is (nil? (find-macro "sym" false))))
 
 (deftest find-fully-qualified-random-name
-  (is (nil? (find-macro "asdf"))))
+  (is (nil? (find-macro "asdf" false))))
 
 (deftest find-fully-qualified-fn
-  (is (nil? (find-macro "refactor-nrepl.find.find-macros/find-macro"))))
+  (is (nil? (find-macro "refactor-nrepl.find.find-macros/find-macro" false))))
 
 (deftest finds-macro-defined-in-cljc-file
   (is (found? #"defmacro cljc-macro"
-              (find-macro "com.example.macro-def-cljc/cljc-macro"))))
+              (find-macro "com.example.macro-def-cljc/cljc-macro" false))))
 
 (deftest finds-macro-defined-in-cljc-file-and-used-in-clj-file
   (is (found? #"(com.example.macro-def-cljc/cljc-macro :fully-qualified)"
-              (find-macro "com.example.macro-def-cljc/cljc-macro"))))
+              (find-macro "com.example.macro-def-cljc/cljc-macro" false))))
 
 (deftest macro-definitions-are-cached
-  (find-macro "com.example.macro-def/my-macro")
+  (find-macro "com.example.macro-def/my-macro" false)
   (with-redefs [refactor-nrepl.find.find-macros/put-cached-macro-definitions
                 (fn [& _] (throw (ex-info "Cache miss!" {})))]
-    (is (found? #"defmacro my-macro" (find-macro "com.example.macro-def/my-macro"))))
+    (is (found? #"defmacro my-macro" (find-macro "com.example.macro-def/my-macro" false))))
   (reset! @#'refactor-nrepl.find.find-macros/macro-defs-cache {})
   (with-redefs [refactor-nrepl.find.find-macros/put-cached-macro-definitions
                 (fn [& _] (throw (Exception. "Expected!")))]
     (is (thrown-with-msg? Exception #"Expected!"
-                          (find-macro "com.example.macro-def/my-macro")))))
+                          (find-macro "com.example.macro-def/my-macro" false)))))


### PR DESCRIPTION
I feel like we should have a way to ignore macro analyzer exceptions the same way we do it in `find-global-symbol` here https://github.com/clojure-emacs/refactor-nrepl/blob/75f5255f0e4e701f50d30cc58216e03c2d558905/src/refactor_nrepl/find/find_symbol.clj#L133.

Global symbols / macros analyzing can be really tricky sometimes and it fails with similar errors in some of my own projects too. Unfortunately, setting `cljr-ignore-analyzer-errors flag` is not taken into consideration in macro search process. I tried to improve it here.
