### PR TITLE
[Fix #278] find-symbol memory leak fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[nrepl "0.5.3"]
                  ^:inline-dep [http-kit "2.3.0"]
                  ^:inline-dep [cheshire "5.8.1"]
-                 ^:inline-dep [org.clojure/tools.analyzer.jvm "0.7.2"]
+                 ^:inline-dep [org.clojure/tools.analyzer.jvm "0.7.3"]
                  ^:inline-dep [org.clojure/tools.namespace "0.3.1" :exclusions [org.clojure/tools.reader]]
                  ^:inline-dep [org.clojure/tools.reader "1.3.2"]
                  ^:inline-dep [cider/orchard "0.5.4"]

--- a/src/refactor_nrepl/analyzer.clj
+++ b/src/refactor_nrepl/analyzer.clj
@@ -28,16 +28,17 @@
   a map of the aliases for the namespace as the second element
   in the same format as ns-aliases"
   [body]
-  (let [ns-decl (read-ns-decl (PushbackReader. (java.io.StringReader. body)))
-        aliases (->> ns-decl
-                     (filter list?)
-                     (some #(when (#{:require} (first %)) %))
-                     rest
-                     (remove symbol?)
-                     (filter #(contains? (set %) :as))
-                     (#(zipmap (map (partial get-alias nil) %)
-                               (map first %))))]
-    [(second ns-decl) aliases]))
+  (with-open [string-reader (java.io.StringReader. body)]
+    (let [ns-decl (read-ns-decl (PushbackReader. string-reader))
+          aliases (->> ns-decl
+                       (filter list?)
+                       (some #(when (#{:require} (first %)) %))
+                       rest
+                       (remove symbol?)
+                       (filter #(contains? (set %) :as))
+                       (#(zipmap (map (partial get-alias nil) %)
+                                 (map first %))))]
+      [(second ns-decl) aliases])))
 
 (defn- noop-macroexpand-1 [form]
   form)


### PR DESCRIPTION
Before I found a real cause of memory leak I tried to analyze and optimize all the functions that are called within `find-symbol` hoping that one of them was the culprit. Eventually I found this line: `(str/join "/" (remove nil? [full-class (:field node)]))))` which was the direct problem.

Looks like `full-class` may become a really huge map in some cases, huge (or complicated) enough that it cannot be stringified correctly by `str/join` which immediately leads to a memory leak.

Having found the real cause, I didn't rollback all the optimization I did before. Hopefully you will find them useful. If not, I'm happy to roll them back.
