### PR TITLE
[clj-refactor.el #443] Add support for js literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [clojure-emacs/clj-refactor.el#443](https://github.com/clojure-emacs/clj-refactor.el/issues/443) `clean-ns` support namespaces with js literal (#js).
 * [#251](https://github.com/clojure-emacs/refactor-nrepl/pull/251) `clean-ns` support extra message key `relative-path`, which will be used if `path` does not exist.
 * [#256](https://github.com/clojure-emacs/refactor-nrepl/pull/256) ignore malformed artifact coordinates when fetching from Clojars.
 * [#264](https://github.com/clojure-emacs/refactor-nrepl/pull/264) less bandwidth used to fetch artifacts from Clojars

--- a/src/refactor_nrepl/find/symbols_in_file.clj
+++ b/src/refactor_nrepl/find/symbols_in_file.clj
@@ -56,7 +56,9 @@
                          (ns-parser/get-libspecs-from-file :cljs (io/file path)))
                         (ns-aliases file-ns))]
        (binding [*ns* file-ns
-                 reader/*data-readers* *data-readers*
+                 reader/*data-readers* (merge (when (= dialect :cljs)
+                                                {'js identity})
+                                              *data-readers*)
                  clojure.tools.reader/*alias-map* ns-aliases]
          (let [rdr (-> path slurp core/file-content-sans-ns
                        readers/indexing-push-back-reader)

--- a/test/resources/cljsns.cljs
+++ b/test/resources/cljsns.cljs
@@ -4,6 +4,7 @@
             [cljsjs.js-yaml] ; this one should not be pruned as it contains externs
             [clojure.string :refer [split-lines join]]
             [cljs.pprint :as pprint]
+            [resources.js-literal-ns :as js-literal]
             [resources.keyword-ns :as kw]
             [clojure.set :as set])
   (:require-macros [cljs.test :refer [testing]]
@@ -34,6 +35,8 @@
 
 (cljs.analyzer.api/no-warn
  :body)
+
+#js [{:foo #js [::js-literal/bar]}]
 
 ;; Caused reader to crash for cljs
 ;; https://github.com/clojure-emacs/clj-refactor.el/issues/353

--- a/test/resources/cljsns_cleaned.cljs
+++ b/test/resources/cljsns_cleaned.cljs
@@ -4,6 +4,7 @@
             cljsjs.js-yaml
             [clojure.set :as set]
             [clojure.string :refer [join split-lines]]
+            [resources.js-literal-ns :as js-literal]
             [resources.keyword-ns :as kw])
   (:require-macros cljs.analyzer.api
                    [cljs.analyzer.macros :as am]

--- a/test/resources/js_literal_ns.cljs
+++ b/test/resources/js_literal_ns.cljs
@@ -1,0 +1,3 @@
+(ns resources.js-literal-ns)
+
+::bar


### PR DESCRIPTION
As described in
https://github.com/clojure-emacs/clj-refactor.el/issues/443, it was
impossible to use clj-clean-ns when a js literal was present:

'No reader function for tag js'

One possible solution was to use *default-data-reader-fn* with the
function `(fn [_tag value] value)`. However this had the potential of
swallowing useful error messages when dealing with other undefined
tags.

The chosen solution is to provide a dummy reader function specifically
for the #js tag (and only for the :cljs dialect). Rather than
transforming the provided form into a JS object, it returns the
clojure form, which can then be analyzed normally.

---------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [N/A] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (run `lein do clean, test`)
- [X] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [N/A] You've updated the readme (if adding/changing user-visible functionality)
