### PR TITLE
Treat uneval nodes as comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [#294](https://github.com/clojure-emacs/refactor-nrepl/pull/294): Properly skip uneval nodes when looking for the first/last sexp
+
 ## 2.5.1 (2021-02-16)
 
 ### Bugs fixed

--- a/test/refactor_nrepl/s_expressions_test.clj
+++ b/test/refactor_nrepl/s_expressions_test.clj
@@ -10,6 +10,9 @@
   #{foo bar baz}
   ;; some other stuff
   (foobar baz)")
+(def file-content-with-uneval "#_ foo
+(foobar baz)")
+
 (def binding-location [3 8])
 (def set-location [7 35])
 (def map-location [7 28])
@@ -33,3 +36,9 @@
            (apply sut/get-enclosing-sexp file-content when-not-location)))
   (t/is (= nil (sut/get-first-sexp weird-file-content)))
   (t/is (=  "#{foo bar baz}" (sut/get-first-sexp file-content-with-set))))
+
+(t/deftest get-first-sexp
+  (t/is (= "(ns resources.testproject.src.com.example.sexp-test)"
+           (sut/get-first-sexp file-content)))
+  (t/is (= "(foobar baz)"
+           (sut/get-first-sexp file-content-with-uneval))))


### PR DESCRIPTION
Uneval nodes throw an UnsupportedOperationException if node/sexpr is
called on them, which will break get-first-sexp if it is given
file-content that starts with `#_ whatever`.

This includes uneval nodes in the set of nodes we should skip when
looking for first & last sexps.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
  - there is no `CONTRIBUTING.md`, I assume this should be `.github/CONTRIBUTING.md`?
- [X] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (run `lein do clean, test`) 
  - No! I get:
```
Exception in thread "main" java.lang.RuntimeException: Map literal must contain an even number of forms, compiling:(refactor_nrepl/artifacts.clj:25:1)
```
But I get the same thing on `master`, so I'm not sure what is going on there.
 
- [ ] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
  - There is no `./build.sh`. I have installed this with `lein with-profile +plugin.mranderson/config install` and have confirmed it is working for me.
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
