### PR TITLE
Address most reflection warnings / cleanup CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,10 +173,6 @@ workflows:
       - util_job:
           name: Code Linting
           steps:
-            # - run:
-            #     name: Running Eastwood
-            #     command: |
-            #       make eastwood
             - run:
                 name: Running cljfmt
                 command: |
@@ -185,4 +181,8 @@ workflows:
                 name: Running clj-kondo
                 command: |
                   make kondo
+            - run:
+                name: Running Eastwood
+                command: |
+                  make eastwood
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,20 +10,30 @@ version: 2.1
 
 defaults: &defaults
   working_directory: ~/repo
-  environment:
-    LEIN_ROOT: "true"   # we intended to run lein as root
-    JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
 
-# Runners for OpenJDK 8 and 11
+# Runners for OpenJDK 8/11/16
 
 executors:
   openjdk8:
     docker:
       - image: circleci/clojure:openjdk-8-lein-2.9.1-node
+    environment:
+      LEIN_ROOT: "true"   # we intended to run lein as root
+      JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
     <<: *defaults
   openjdk11:
     docker:
       - image: circleci/clojure:openjdk-11-lein-2.9.1-node
+    environment:
+      LEIN_ROOT: "true"   # we intended to run lein as root
+      JVM_OPTS: -Xmx3200m --illegal-access=deny # forbid reflective access
+    <<: *defaults
+  openjdk16:
+    docker:
+      - image: circleci/clojure:openjdk-16-lein-2.9.5-buster-node
+    environment:
+      LEIN_ROOT: "true"   # we intended to run lein as root
+      JVM_OPTS: -Xmx3200m --illegal-access=deny # forbid reflective access
     <<: *defaults
 
 # Runs a given set of steps, with some standard pre- and post-
@@ -139,37 +149,11 @@ workflows:
   ci-test-matrix:
     jobs:
       - test_code:
-          name: Java 8, Clojure 1.8
-          clojure_version: "1.8"
-          jdk_version: openjdk8
-      - test_code:
-          name: Java 8, Clojure 1.9
-          clojure_version: "1.9"
-          jdk_version: openjdk8
-      - test_code:
-          name: Java 8, Clojure 1.10
-          clojure_version: "1.10"
-          jdk_version: openjdk8
-      # - test_code:
-      #     name: Java 8, Clojure master
-      #     clojure_version: "master"
-      #     jdk_version: openjdk8
-      - test_code:
-          name: Java 11, Clojure 1.8
-          clojure_version: "1.8"
-          jdk_version: openjdk11
-      - test_code:
-          name: Java 11, Clojure 1.9
-          clojure_version: "1.9"
-          jdk_version: openjdk11
-      - test_code:
-          name: Java 11, Clojure 1.10
-          clojure_version: "1.10"
-          jdk_version: openjdk11
-      # - test_code:
-      #     name: Java 11, Clojure master
-      #     clojure_version: "master"
-      #     jdk_version: openjdk11
+          matrix:
+            parameters:
+              # TODO: add "master" (tests would fail due to piggieback)
+              clojure_version: ["1.8", "1.9", "1.10"]
+              jdk_version: [openjdk8, openjdk11, openjdk16]
       - util_job:
           name: Code Linting
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,10 +59,6 @@ commands:
           command: |
             sudo apt-get install make
       - run:
-          name: Install clj-kondo
-          command: |
-           sudo curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo && sudo chmod +x install-clj-kondo && sudo ./install-clj-kondo
-      - run:
           name: Generate Cache Checksum
           command: |
             for file in << parameters.files >>

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ cljfmt:
 	lein with-profile +$(VERSION),+cljfmt,+lein-plugin cljfmt check
 
 kondo:
-	clj-kondo --lint src
+	lein with-profile -dev,+$(VERSION),+clj-kondo run -m clj-kondo.main --lint src 
 
 # When releasing, the BUMP variable controls which field in the
 # version string will be incremented in the *next* snapshot

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ test: .inline-deps
 cljfmt:
 	lein with-profile +$(VERSION),+cljfmt,+lein-plugin cljfmt check
 
+eastwood:
+	lein with-profile +$(VERSION),+eastwood eastwood
+
 kondo:
 	lein with-profile -dev,+$(VERSION),+clj-kondo run -m clj-kondo.main --lint src 
 

--- a/project.clj
+++ b/project.clj
@@ -41,8 +41,7 @@
              :lein-plugin {:source-paths ["lein-plugin"]}
              :test {:dependencies [[print-foo "1.0.2"]]
                     :src-paths ["test/resources"]}
-             :dev {:plugins [[jonase/eastwood "0.3.14"]]
-                   :global-vars {*warn-on-reflection* true}
+             :dev {:global-vars {*warn-on-reflection* true}
                    :dependencies [[org.clojure/clojurescript "1.9.946"]
                                   [cider/piggieback "0.5.2"]
                                   [commons-io/commons-io "2.8.0"]]
@@ -59,7 +58,13 @@
                                           cond->* [[:inner 0]]
                                           with-debug-bindings [[:inner 0]]
                                           merge-meta [[:inner 0]]
-                                          try-if-let [[:block 1]]}}}]}
+                                          try-if-let [[:block 1]]}}}]
+             :eastwood {:plugins         [[jonase/eastwood "0.4.0"]]
+                        ;; TODO: add :test-paths
+                        :eastwood {:namespaces      [:source-paths]
+                                   ;; vendored - shouldn't be tweaked for satisfying linters:
+                                   :exclude-namespaces [refactor-nrepl.ns.slam.hound.regrow]
+                                   :exclude-linters [:unused-ret-vals]}}
              :clj-kondo [:test
                          {:dependencies [[clj-kondo "2021.03.31"]]}]}
   :jvm-opts ["-Djava.net.preferIPv4Stack=true"])

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,6 @@
                :expositions     [[org.clojure/tools.analyzer.jvm org.clojure/tools.analyzer]]
                :unresolved-tree false}
   :filespecs [{:type :bytes :path "refactor-nrepl/refactor-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
-
   :profiles {;; Clojure versions matrix
              :provided {:dependencies [[cider/cider-nrepl "0.25.9"]
                                        [org.clojure/clojure "1.8.0"]]}
@@ -37,6 +36,11 @@
                                   [javax.xml.bind/jaxb-api "2.3.1"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.2"]
                                    [org.clojure/clojurescript "1.10.520"]]}
+
+             :master {:repositories [["snapshots"
+                                      "https://oss.sonatype.org/content/repositories/snapshots"]]
+                      :dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"]
+                                     [org.clojure/clojure "1.11.0-master-SNAPSHOT" :classifier "sources"]]}
 
              :lein-plugin {:source-paths ["lein-plugin"]}
              :test {:dependencies [[print-foo "1.0.2"]]

--- a/project.clj
+++ b/project.clj
@@ -60,4 +60,6 @@
                                           with-debug-bindings [[:inner 0]]
                                           merge-meta [[:inner 0]]
                                           try-if-let [[:block 1]]}}}]}
+             :clj-kondo [:test
+                         {:dependencies [[clj-kondo "2021.03.31"]]}]}
   :jvm-opts ["-Djava.net.preferIPv4Stack=true"])

--- a/src/refactor_nrepl/find/find_macros.clj
+++ b/src/refactor_nrepl/find/find_macros.clj
@@ -218,7 +218,7 @@
           origin-ns (symbol (core/prefix fully-qualified-name))
           dependents (tracker/get-dependents tracker origin-ns)]
       (some->> macro-def
-               :file
+               ^String (:file)
                File.
                (conj dependents)
                (mapcat (partial find-usages-in-file [macro-def]))

--- a/src/refactor_nrepl/rename_file_or_dir.clj
+++ b/src/refactor_nrepl/rename_file_or_dir.clj
@@ -125,7 +125,7 @@
 
 (defn- rename-file!
   "Actually rename a file."
-  [old-path new-path]
+  [^String old-path new-path]
   (fs/mkdirs (fs/parent new-path))
   (when-not (fs/rename old-path new-path)
     (throw (ex-info "Failed renaming file!"
@@ -143,7 +143,7 @@
 
 (defn- update-ns!
   "After moving some file to path update its ns to reflect new location."
-  [path old-ns]
+  [^String path old-ns]
   (let [new-ns (path->ns path)
         f (File. path)]
     (->> new-ns
@@ -224,7 +224,7 @@
                    :let [path (util/normalize-to-unix-path (.getAbsolutePath f))]]
                (-rename-file-or-dir path (merge-paths path old-path new-path))))))
 
-(defn- file-or-symlink-exists? [path]
+(defn- file-or-symlink-exists? [^String path]
   (let [f (File. path)]
     (if (.exists f)
       path
@@ -234,7 +234,7 @@
             (when (.. target toFile exists)
               path)))))))
 
-(defn- -rename-file-or-dir [old-path new-path]
+(defn- -rename-file-or-dir [^String old-path new-path]
   (let [affected-files  (if (fs/directory? old-path)
                           (rename-dir old-path new-path)
                           (if ((some-fn core/clj-file? core/cljs-file?)

--- a/test/refactor_nrepl/find/find_macros_test.clj
+++ b/test/refactor_nrepl/find/find_macros_test.clj
@@ -7,8 +7,8 @@
 
 (deftest find-macro-test
   (let [occurrences (find-macro "com.example.macro-def/my-macro" false)
-        {:keys [line-beg col-beg file match]}
-        (first (filter #(.contains (:match %) "defmacro") occurrences))]
+        {:keys [line-beg col-beg ^String file match]}
+        (first (filter #(.contains ^String (:match %) "defmacro") occurrences))]
     (testing "finds the macro definition"
       (is (found? #"defmacro my-macro" occurrences)))
     (testing "finds fully qualified reference"

--- a/test/refactor_nrepl/integration_tests.clj
+++ b/test/refactor_nrepl/integration_tests.clj
@@ -55,7 +55,7 @@
 
       (is (some (partial re-matches #"(?s).*two.clj \[3\].*") result) "def of foo not found in ns com.example.two"))))
 
-(defn ns-ast-throw-error-for-five [content]
+(defn ns-ast-throw-error-for-five [^String content]
   (if (.contains content "com.example.five")
     (throw (IllegalThreadStateException. "FAILED!"))
     (#'refactor-nrepl.analyzer/cachable-ast content)))
@@ -89,7 +89,7 @@
           result (remove keyword? response)]
       ;;(clojure.pprint/pprint result)
 
-      (is (not-any? #(.contains % "(assert (> x 0)") result) "`assert` found when searching for `clojure.core/str`"))))
+      (is (not-any? #(.contains ^String % "(assert (> x 0)") result) "`assert` found when searching for `clojure.core/str`"))))
 
 (deftest test-shouldnt-find-expanded-fn-in-place-of-macro
   (with-testproject-on-classpath
@@ -101,7 +101,7 @@
           result (remove keyword? response)]
       ;;(clojure.pprint/pprint result)
 
-      (is (not-any? #(.contains % "(nicely x)") result) "`str-nicely` found at macro call site"))))
+      (is (not-any? #(.contains ^String % "(nicely x)") result) "`str-nicely` found at macro call site"))))
 
 (deftest test-find-fn-in-similarly-named-ns
   (with-testproject-on-classpath

--- a/test/refactor_nrepl/rename_file_or_dir_test.clj
+++ b/test/refactor_nrepl/rename_file_or_dir_test.clj
@@ -35,7 +35,7 @@
                   refactor-nrepl.rename-file-or-dir/update-ns! (fn [path old-ns])
                   refactor-nrepl.rename-file-or-dir/update-dependents!
                   (fn [deps]
-                    (doseq [[path content] deps]
+                    (doseq [[^String path content] deps]
                       (when (.endsWith path "clj")
                         (swap! dependents conj content))))]
       (rename-file-or-dir from-file-path to-file-path)
@@ -58,7 +58,7 @@
                     (doseq [[f content] deps]
                       (swap! dependents conj [f content])))]
       (rename-file-or-dir from-file-path to-file-path)
-      (doseq [[f content] @dependents
+      (doseq [[^String f ^String content] @dependents
               :when (.endsWith f "ns2.clj")]
         (is (.contains content new-ns-ref))
         (is (not (.contains content old-ns-ref)))
@@ -82,7 +82,7 @@
 
                   refactor-nrepl.rename-file-or-dir/update-dependents!
                   (fn [deps]
-                    (doseq [[path content] deps]
+                    (doseq [[^String path content] deps]
                       (when (.endsWith path ".clj")
                         (swap! dependents conj content))))]
       (rename-file-or-dir from-dir-path to-dir-path)
@@ -114,7 +114,7 @@
                     (doseq [[f content] deps]
                       (swap! dependents conj [f content])))]
       (rename-file-or-dir from-dir-path to-dir-path)
-      (doseq [[f content] @dependents
+      (doseq [[^String f ^String content] @dependents
               :when (.endsWith f "ns2.clj")]
         (is (.contains content new-ns-ref-dir))
         (is (not (.contains content old-ns-ref-dir)))
@@ -131,7 +131,7 @@
                   refactor-nrepl.rename-file-or-dir/update-dependents! (fn [deps])]
       (rename-file-or-dir from-dir-path to-dir-path)
       (is (= (count @files) 9))
-      (doseq [[old new] @files]
+      (doseq [[^String old ^String new] @files]
         (is (.contains old "/move/"))
         (is (.contains new "/moved/"))))))
 
@@ -143,8 +143,8 @@
                   refactor-nrepl.rename-file-or-dir/update-ns! (fn [path old-ns])
                   refactor-nrepl.rename-file-or-dir/update-dependents! (fn [deps])]
       (rename-file-or-dir from-dir-path to-dir-path)
-      (is (some #(.endsWith % "non_clj_file") @files))
-      (is (= 4 (count (filter #(.endsWith % ".cljs") @files)))))))
+      (is (some #(.endsWith ^String % "non_clj_file") @files))
+      (is (= 4 (count (filter #(.endsWith ^String % ".cljs") @files)))))))
 
 
 ;;; cljs
@@ -187,7 +187,7 @@
                     (doseq [[f content] deps]
                       (swap! dependents conj [f content])))]
       (rename-file-or-dir from-file-path-cljs to-file-path-cljs)
-      (doseq [[f content] @dependents
+      (doseq [[^String f ^String content] @dependents
               :when (.endsWith f "ns2.cljs")]
         (is (.contains content new-ns-ref))
         (is (not (.contains content old-ns-ref)))
@@ -211,7 +211,7 @@
 
                   refactor-nrepl.rename-file-or-dir/update-dependents!
                   (fn [deps]
-                    (doseq [[path content] deps]
+                    (doseq [[^String path content] deps]
                       (when (.endsWith path ".cljs")
                         (swap! dependents conj content))))]
       (rename-file-or-dir from-dir-path to-dir-path)
@@ -246,7 +246,7 @@
                     (doseq [[f content] deps]
                       (swap! dependents conj [f content])))]
       (rename-file-or-dir from-dir-path to-dir-path)
-      (doseq [[f content] @dependents
+      (doseq [[^String f ^String content] @dependents
               :when (.endsWith f "ns2.cljs")]
         (is (.contains content new-ns-ref-dir))
         (is (not (.contains content old-ns-ref-dir)))
@@ -263,7 +263,7 @@
                   refactor-nrepl.rename-file-or-dir/update-dependents! (fn [deps])]
       (rename-file-or-dir from-dir-path to-dir-path)
       (is (= (count @files) 9))
-      (doseq [[old new] @files]
+      (doseq [[^String old ^String new] @files]
         (is (.contains old "/move/"))
         (is (.contains new "/moved/"))))))
 
@@ -275,5 +275,5 @@
                   refactor-nrepl.rename-file-or-dir/update-ns! (fn [path old-ns])
                   refactor-nrepl.rename-file-or-dir/update-dependents! (fn [deps])]
       (rename-file-or-dir from-dir-path to-dir-path)
-      (is (some #(.endsWith % "non_clj_file") @files))
-      (is (= 4 (count (filter #(.endsWith % ".clj") @files)))))))
+      (is (some #(.endsWith ^String % "non_clj_file") @files))
+      (is (= 4 (count (filter #(.endsWith ^String % ".clj") @files)))))))


### PR DESCRIPTION
* Run clj-kondo by a more stable means
* Run Eastwood in CI again
  * only src for now, as the `test` setup is a bit intrincate with multiple/nested source-paths
* CI: adopt matrix syntax
* Address most reflection warnings
  * All `src/` warnings are gone