### PR TITLE
Change default to no prefix re-writing

### DIFF
--- a/src/refactor_nrepl/config.clj
+++ b/src/refactor_nrepl/config.clj
@@ -13,7 +13,7 @@
    :prune-ns-form true
 
    ;; Should `clean-ns` favor prefix forms in the ns macro?
-   :prefix-rewriting true
+   :prefix-rewriting false
 
    ;; Should `pprint-ns` place a newline after the `:require` and `:import` tokens?
    :insert-newline-after-require true

--- a/test/resources/ns1_cleaned_and_pprinted_prefix_notation
+++ b/test/resources/ns1_cleaned_and_pprinted_prefix_notation
@@ -9,15 +9,13 @@
    :extends java.lang.Exception
    :methods [[binomial [int int] double]])
   (:require
-   clojure.data
-   clojure.edn
-   [clojure.instant :as inst :reload true]
-   [clojure.pprint :refer [cl-format formatter get-pretty-writer]]
-   [clojure.string :refer :all :reload-all true]
-   [clojure.test :refer :all]
-   clojure.test.junit
-   [clojure.walk :refer [postwalk prewalk]]
-   clojure.xml)
+   [clojure data edn xml
+    [instant :as inst :reload true]
+    [pprint :refer [cl-format formatter get-pretty-writer]]
+    [string :refer :all :reload-all true]
+    [test :refer :all]
+    [walk :refer [postwalk prewalk]]]
+   clojure.test.junit)
   (:import
    [java.io Closeable FilenameFilter PushbackReader]
    [java.util Calendar Date Random]


### PR DESCRIPTION
The default has already been changed in clj-refactor so this is
essentially a no-op, but makes the change more explicit for those
working on the middleware.

