### PR TITLE
[#Fix 289] Namespaced keywords vs find (local) symbol 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Bugs fixed
+* [#289](https://github.com/clojure-emacs/refactor-nrepl/issues/289): Fix an edge-case with involving keywords that caused find-symbol to crash.
 * [#305](https://github.com/clojure-emacs/refactor-nrepl/issues/305): Don't put `:as` or `:refer` on their own lines in the ns form, when the libspec is so long it causes the line to wrap.
 * [clojure-emacs/clj-refactor.el#459](https://github.com/clojure-emacs/clj-refactor.el/issues/459): `clean-ns` should conform to the style guide: `(:require` in the ns form should be followed by a newline.
   * You can opt out via the new `:insert-newline-after-require` configuration option.

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
   :filespecs [{:type :bytes :path "refactor-nrepl/refactor-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
   :profiles {;; Clojure versions matrix
              :provided {:dependencies [[cider/cider-nrepl "0.25.9"]
-                                       [org.clojure/clojure "1.8.0"]]}
+                                       [org.clojure/clojure "1.9.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/clojurescript "1.8.51"]
                                   [javax.xml.bind/jaxb-api "2.3.1"]]}

--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -25,7 +25,11 @@
 (defn ns-from-string
   "Retrieve the symbol naming the ns from file-content."
   [file-content]
-  (second (parse/read-ns-decl (PushbackReader. (java.io.StringReader. file-content)))))
+  (-> file-content
+      java.io.StringReader.
+      PushbackReader.
+      parse/read-ns-decl
+      second))
 
 (defn ns-name-from-readable
   "Call slurp on readable and extract the ns-name from the content."

--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -380,3 +380,12 @@
   [symbol-or-keyword]
   (when (prefix symbol-or-keyword)
     symbol-or-keyword))
+
+(defmacro with-clojure-version->=
+  "Guard the evaluation of `body` with a test on the current clojure version."
+  {:style/indent 1}
+  [{:keys [major minor] :as _clojure-version} & body]
+  (when (or (> (:major *clojure-version*) major)
+            (and (= (:major *clojure-version*) major)
+                 (>= (:minor *clojure-version*) minor)))
+    `(do ~@body)))

--- a/test/resources/testproject/src/com/example/five.clj
+++ b/test/resources/testproject/src/com/example/five.clj
@@ -1,5 +1,6 @@
 (ns com.example.five
-  (:require [clojure.string :refer [join split blank? trim] :as str]))
+  (:require [clojure.string :refer [join split blank? trim] :as str]
+            [refactor-nrepl.core :as core]))
 
 ;;  remove parameters to run the tests
 (defn fn-with-unbounds [s sep]
@@ -57,6 +58,13 @@
   (let [{:keys [foo bar] :or {foo "foo"}} (hash-map)]
     [:bar :foo]
     (count foo)))
+
+(core/with-clojure-version->= {:major 1 :minor 9}
+  (defn fn-with-let-with-namespaced-keyword-destructuring []
+    ;; https://github.com/clojure-emacs/refactor-nrepl/issues/289
+    (let [{::str/keys [foo bar]} (hash-map)]
+      [:bar :foo]
+      (count foo))))
 
 ;; This was causing both find-local-symbol and find-macros to blow up, for
 ;; different reasons


### PR DESCRIPTION
The edge-case handling for local symbols in opt-maps wasn't using a
reader that was configured correctly and choked on a namespaced keyword.

This PR will also drop support for clojure 1.8:

Destructuring with namespaced keywords was added in clojure 1.9 and
this feature is now referenced in our tests.

According to the state of Clojure 2021 survey only 6.36% of users are
still using this version for development or production.  Since Clojure
is a provided dep in this project they can continue to due so but
'official support' ends as we move to version 3.0.0.

