### PR TITLE
Fix a test

### DIFF
--- a/test/refactor_nrepl/ns/namespace_aliases_test.clj
+++ b/test/refactor_nrepl/ns/namespace_aliases_test.clj
@@ -1,48 +1,41 @@
 (ns refactor-nrepl.ns.namespace-aliases-test
-  (:require [clojure.test :as t]
+  (:require [clojure.test :refer [deftest is]]
             [refactor-nrepl.core :as core]
             [refactor-nrepl.ns.libspecs :as sut]
             [refactor-nrepl.util :as util]))
 
-(t/deftest finds-the-aliases-in-this-ns
-  (let [aliases (:clj (sut/namespace-aliases))]
-    (t/is (some (fn [alias]
-                  (and (= (first alias) 'sut)
-                       (= (some #(= % 'refactor-nrepl.ns.namespace-aliases)
-                                (second alias)))))
-                aliases))))
+(defn finds [selector alias libspec]
+  (let [aliases (selector (sut/namespace-aliases))]
+    (some (fn [[k vs]]
+            (and (= k alias)
+                 (some #{libspec} vs)))
+          aliases)))
 
-(t/deftest finds-the-cljs-aliases-in-cljsns
-  (let [aliases (:cljs (sut/namespace-aliases))]
-    (t/is (some #(and (= (first %) 'pprint)
-                      (= (first (second %)) 'cljs.pprint))
-                aliases))))
+(deftest finds-the-aliases-in-this-ns
+  (is (finds :clj 'sut 'refactor-nrepl.ns.libspecs)))
 
-(t/deftest finds-the-clj-aliases-in-namespace-aliases
-  (let [aliases (:clj (sut/namespace-aliases))]
-    (t/is (some #(and (= (first %) 'clojure-string)
-                      (= (first (second %)) 'clojure.string))
-                aliases))))
+(deftest finds-the-cljs-aliases-in-cljsns
+  (is (finds :cljs 'pprint 'cljs.pprint)))
 
-(t/deftest finds-the-cljs-aliases-in-namespace-aliases
-  (let [aliases (:cljs (sut/namespace-aliases))]
-    (t/is (some #(and (= (first %) 'gstr)
-                      (= (first (second %)) 'goog.string))
-                aliases))))
+(deftest finds-the-clj-aliases-in-namespace-aliases
+  (is (finds :clj 'clojure-string 'clojure.string)))
 
-(t/deftest sorts-by-frequencies
+(deftest finds-the-cljs-aliases-in-namespace-aliases
+  (is (finds :cljs 'gstr 'goog.string)))
+
+(deftest sorts-by-frequencies
   (let [aliases (:clj (sut/namespace-aliases))
         _ (core/ns-form-from-string "(ns foo)")
         utils (get (util/filter-map #(= (first %) 'util) aliases) 'util)]
-    (t/is (= (first utils) 'refactor-nrepl.util))))
+    (is (= (first utils) 'refactor-nrepl.util))))
 
-(t/deftest libspecs-are-cached
+(deftest libspecs-are-cached
   (sut/namespace-aliases)
   (with-redefs [refactor-nrepl.ns.libspecs/put-cached-libspec
                 (fn [& _] (throw (ex-info "Cache miss!" {})))]
-    (t/is (sut/namespace-aliases)))
+    (is (sut/namespace-aliases)))
   (reset! @#'sut/cache {})
   (with-redefs [refactor-nrepl.ns.libspecs/put-cached-libspec
                 (fn [& _] (throw (Exception. "Expected!")))]
-    (t/is (thrown-with-msg? Exception #"Expected!"
-                            (sut/namespace-aliases)))))
+    (is (thrown-with-msg? Exception #"Expected!"
+                          (sut/namespace-aliases)))))


### PR DESCRIPTION
It used a single-handed `=`: `(= (some #(= % 'refactor-nrepl.ns.namespace-aliases) ...`, which was making the test invalid.

While I was there, I also DRYed related deftests.