### PR TITLE
Observe thread interruption status for cancellable tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * This increases the chances that a namespace will be found, which in turns makes refactor-nrepl more complete/accurate.
 * Replace Cheshire with `clojure.data.json`
 * Build ASTs more robustly (by using locks and ruling out certain namespaces like refactor-nrepl itself)
+* Honor internal `future-cancel` calls, improving overall responsiveness and stability.
 
 ### Bugs fixed
 * [#289](https://github.com/clojure-emacs/refactor-nrepl/issues/289): Fix an edge-case with involving keywords that caused find-symbol to crash.

--- a/src/refactor_nrepl/ns/tracker.clj
+++ b/src/refactor_nrepl/ns/tracker.clj
@@ -55,7 +55,8 @@
   (let [deps (dep/immediate-dependents (:clojure.tools.namespace.track/deps tracker)
                                        (symbol my-ns))]
     (for [[file ns] (:clojure.tools.namespace.file/filemap tracker)
-          :when ((set deps) ns)]
+          :when ((set deps) ns)
+          :when (not (util/interrupted?))]
       file)))
 
 (defn- in-refresh-dirs? [refresh-dirs file]

--- a/src/refactor_nrepl/ns/tracker.clj
+++ b/src/refactor_nrepl/ns/tracker.clj
@@ -53,10 +53,11 @@
   "Get the dependent files for ns from tracker."
   [tracker my-ns]
   (let [deps (dep/immediate-dependents (:clojure.tools.namespace.track/deps tracker)
-                                       (symbol my-ns))]
+                                       (symbol my-ns))
+        deps-set (set deps)]
     (for [[file ns] (:clojure.tools.namespace.file/filemap tracker)
-          :when ((set deps) ns)
-          :when (not (util/interrupted?))]
+          :when (and (not (util/interrupted?))
+                     (deps-set ns))]
       file)))
 
 (defn- in-refresh-dirs? [refresh-dirs file]

--- a/src/refactor_nrepl/util.clj
+++ b/src/refactor_nrepl/util.clj
@@ -95,5 +95,7 @@
   Observing this condition helps `future-cancel` effectively cancel `future`s."
   ([]
    (interrupted? ::_))
-  ([_x]
+  ;; The arity with a "useless" arg is there so that this can be used as a predicate
+  ;; in other places that already are using `some-fn`, `every-pred`, etc
+  ([_]
    (.isInterrupted (Thread/currentThread))))

--- a/src/refactor_nrepl/util.clj
+++ b/src/refactor_nrepl/util.clj
@@ -88,3 +88,12 @@
           (maybe-log-exception e)
           ;; return false, because `with-suppressed-errors` is oriented for predicate usage
           false)))))
+
+(defn interrupted?
+  "Has the current thread been interrupted?
+
+  Observing this condition helps `future-cancel` effectively cancel `future`s."
+  ([]
+   (interrupted? ::_))
+  ([_x]
+   (.isInterrupted (Thread/currentThread))))


### PR DESCRIPTION
Otherwise `future-cancel` wouldn't do much - at least from what I can infer reading the code.

Fixes https://github.com/clojure-emacs/refactor-nrepl/issues/316
