### PR TITLE
Parallelize `referred-syms-by-file&fullname`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 #### Changes
+* [(Part of #230)](https://github.com/clojure-emacs/refactor-nrepl/issues/230) Parallelize various fuctionality
+  * This will have a noticeable improvement in e.g. clj-refactor.el's `cljr-slash` performance.
 * [#291](https://github.com/clojure-emacs/refactor-nrepl/issues/291): The `:ignore-errors` option will be honored in more places, making refactor-nrepl more robust in face of files not particularly meant to be part of the AST corpus.
   * Examples: WIP files, Moustache template files, scripts.
 * Upgrade Orchard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 #### Changes
-* [(Part of #230)](https://github.com/clojure-emacs/refactor-nrepl/issues/230) Parallelize various fuctionality
+
+* [(Part of #230)](https://github.com/clojure-emacs/refactor-nrepl/issues/230): Parallelize various functionality
   * This will have a noticeable improvement in e.g. clj-refactor.el's `cljr-slash` performance.
 * [#291](https://github.com/clojure-emacs/refactor-nrepl/issues/291): The `:ignore-errors` option will be honored in more places, making refactor-nrepl more robust in face of files not particularly meant to be part of the AST corpus.
   * Examples: WIP files, Moustache template files, scripts.
@@ -17,6 +18,7 @@
 * Honor internal `future-cancel` calls, improving overall responsiveness and stability.
 
 ### Bugs fixed
+
 * [#289](https://github.com/clojure-emacs/refactor-nrepl/issues/289): Fix an edge-case with involving keywords that caused find-symbol to crash.
 * [#305](https://github.com/clojure-emacs/refactor-nrepl/issues/305): Don't put `:as` or `:refer` on their own lines in the ns form, when the libspec is so long it causes the line to wrap.
 * [clojure-emacs/clj-refactor.el#459](https://github.com/clojure-emacs/clj-refactor.el/issues/459): `clean-ns` should conform to the style guide: `(:require` in the ns form should be followed by a newline.

--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -104,6 +104,7 @@
   [pred dir]
   (->> dir
        file-seq
+       ;; `pmap` performs better in large projects.
        (pmap (fn [f]
                (when ((every-pred fs/exists?
                                   (complement fs/hidden?)

--- a/src/refactor_nrepl/ns/libspecs.clj
+++ b/src/refactor_nrepl/ns/libspecs.clj
@@ -77,7 +77,7 @@
 
 (defn referred-syms-by-file&fullname
   "Return a map of filename to a map of sym fullname to sym
-   the sym itself
+   the sym itself.
 
    Example:
    {:clj  {\"/home/someuser/projects/some.clj\" [\"example.com/foobar\" foobar]}
@@ -85,6 +85,7 @@
   ([]
    (referred-syms-by-file&fullname false))
   ([ignore-errors?]
+   ;; `pmap` is used as it has proved to be more efficient, both for cached and non-cached cases.
    {:clj  (->> (core/find-in-project (util/with-suppressed-errors
                                        (some-fn core/clj-file? core/cljc-file?)
                                        ignore-errors?))

--- a/src/refactor_nrepl/ns/libspecs.clj
+++ b/src/refactor_nrepl/ns/libspecs.clj
@@ -88,10 +88,10 @@
    {:clj  (->> (core/find-in-project (util/with-suppressed-errors
                                        (some-fn core/clj-file? core/cljc-file?)
                                        ignore-errors?))
-               (map (juxt identity (partial get-libspec-from-file-with-caching :clj)))
+               (pmap (juxt identity (partial get-libspec-from-file-with-caching :clj)))
                sym-by-file&fullname)
     :cljs (->> (core/find-in-project (util/with-suppressed-errors
                                        (some-fn core/cljs-file? core/cljc-file?)
                                        ignore-errors?))
-               (map (juxt identity (partial get-libspec-from-file-with-caching :cljs)))
+               (pmap (juxt identity (partial get-libspec-from-file-with-caching :cljs)))
                sym-by-file&fullname)}))


### PR DESCRIPTION
Part of https://github.com/clojure-emacs/refactor-nrepl/issues/230

Parallelizes `referred-syms-by-file&fullname` and `core/` functions used by `referred-syms-by-file&fullname`.

(the `core/` parallelization will be only noticable in large projects)

One can verify the improvement with the following repl input over refactor-nrepl itself:

```clj
(require 'refactor-nrepl.ns.libspecs)
(in-ns 'refactor-nrepl.ns.libspecs)
(time (referred-syms-by-file&fullname true))
```

...It's clearly better than `master` performance for both the non-cached and cached (i.e. subsequent invocations) cases.

(the numbers of course will depend on your CPU count)