### PR TITLE
Optimize `namespace-aliases`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   * This increases the chances that a namespace will be found, which in turns makes refactor-nrepl more complete/accurate.
 * Replace Cheshire with `clojure.data.json`
 * Build ASTs more robustly (by using locks, `require`, and ruling out certain namespaces like refactor-nrepl itself)
+* Improve `namespace-aliases` performance and make it return more accurate results.
 * Honor internal `future-cancel` calls, improving overall responsiveness and stability.
 
 ### Bugs fixed

--- a/test/refactor_nrepl/core_test.clj
+++ b/test/refactor_nrepl/core_test.clj
@@ -2,14 +2,14 @@
   (:require
    [clojure.test :refer [are deftest is testing]]
    [refactor-nrepl.config :as config]
-   [refactor-nrepl.core :refer [ignore-dir-on-classpath? read-ns-form]])
+   [refactor-nrepl.core :as sut])
   (:import
    (java.io File)))
 
 (defmacro assert-ignored-paths
   [paths pred]
   `(doseq [p# ~paths]
-     (is (~pred (ignore-dir-on-classpath? p#)))))
+     (is (~pred (sut/ignore-dir-on-classpath? p#)))))
 
 (deftest test-ignore-dir-on-classpath?
   (let [not-ignored ["/home/user/project/test"
@@ -32,9 +32,16 @@
   (are [input expected] (testing input
                           (assert (-> input File. .exists))
                           (is (= expected
-                                 (read-ns-form input)))
+                                 (sut/read-ns-form input)))
                           true)
     "test-resources/readable_file_incorrect_aliases.clj" nil
     "testproject/src/com/example/one.clj"                '(ns com.example.one
                                                             (:require [com.example.two :as two :refer [foo]]
                                                                       [com.example.four :as four]))))
+
+(deftest source-files-with-clj-like-extension-test
+  (let [result (sut/source-files-with-clj-like-extension true)]
+    (doseq [extension [".clj" ".cljs" ".cljc"]]
+      (is (pos? (count (filter (fn [^File f]
+                                 (-> f .getPath (.endsWith extension)))
+                               result)))))))

--- a/test/refactor_nrepl/ns/namespace_aliases_test.clj
+++ b/test/refactor_nrepl/ns/namespace_aliases_test.clj
@@ -1,12 +1,13 @@
 (ns refactor-nrepl.ns.namespace-aliases-test
-  (:require [clojure.test :refer [deftest is]]
-            [refactor-nrepl.core :as core]
-            [refactor-nrepl.ns.libspecs :as sut]
-            [refactor-nrepl.util :as util]
-            [refactor-nrepl.unreadable-files :refer [ignore-errors?]]))
+  (:require
+   [clojure.test :refer [deftest is]]
+   [refactor-nrepl.core :as core]
+   [refactor-nrepl.ns.libspecs :as sut]
+   [refactor-nrepl.unreadable-files :refer [ignore-errors?]]
+   [refactor-nrepl.util :as util]))
 
 (defn finds [selector alias libspec]
-  (let [aliases (selector (sut/namespace-aliases ignore-errors?))]
+  (let [aliases (selector (sut/namespace-aliases ignore-errors? (core/dirs-on-classpath)))]
     (some (fn [[k vs]]
             (and (= k alias)
                  (some #{libspec} vs)))

--- a/test/refactor_nrepl/util_test.clj
+++ b/test/refactor_nrepl/util_test.clj
@@ -1,6 +1,9 @@
 (ns refactor-nrepl.util-test
-  (:require [clojure.test :refer [deftest is]]
-            [refactor-nrepl.util :as sut]))
+  (:require
+   [clojure.test :refer [are deftest is]]
+   [refactor-nrepl.util :as sut])
+  (:import
+   (java.io File)))
 
 (deftest with-additional-ex-data-test
   (try
@@ -10,3 +13,22 @@
     (catch clojure.lang.ExceptionInfo e
       (let [{:keys [foo]} (ex-data e)]
         (is (= foo :bar))))))
+
+(deftest dir-outside-root-dir?-test
+  (are [input expected] (= expected
+                           (sut/dir-outside-root-dir? input))
+    (File. (System/getProperty "user.dir")) false
+    (File. ".")                             false
+    (File. "src")                           false
+    (File. "/")                             true))
+
+(deftest data-file?-test
+  (are [input expected] (= expected
+                           (sut/data-file? input))
+    "project.clj"       true
+    "boot.clj"          true
+    "data_readers.clj"  true
+    "project.cljs"      false
+    "boot.cljs"         false
+    "data_readers.cljs" false
+    "a.clj"             false))


### PR DESCRIPTION
Optimizes this defn via 3 techniques:

* Consolidates the common work to be done across :clj / :cljs dialects
* Parallelizes the work, per dialect
* and shrinks the corpus by removing non source/test dirs from the classpath.
  *  (this is the most important gain for small/medium projects)

Testing it over refactor-nrepl itself, I got a performance gain from 70ms (cached case) to 20ms (cached case).

The performance gains can be larger as projects scale. It also can plausibly ameliorate the mistery slowness for the :cljs branch.

Fixes https://github.com/clojure-emacs/refactor-nrepl/issues/230 (see https://github.com/clojure-emacs/refactor-nrepl/issues/230#issuecomment-921093775)