### PR TITLE
Fix `in-refresh-dirs?`

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,5 +1,43 @@
 ;; `nrepl.core/code` can contain intentionally broken code in the test suite, so we silence related resolution errors:
 {:lint-as {nrepl.core/code clojure.core/quote}
- :linters {:unresolved-symbol {:exclude [(refactor-nrepl.ns.ns-parser/with-libspecs-from [libspecs])
-                                         (refactor-nrepl.middleware/set-descriptor! [set-descriptor!])]}
+ ;; Set up :refer linter, mainly for banning the refer-ing of `refresh-dirs`. We don't want to accidentally shadow it in related code.
+ ;; Feel free to add more :exclude entries - we're unopinionated about :refer (if anything, refactor-nrepl facilitates the usage of :refer)
+ :linters {:refer {:level :warning
+                   :exclude [clojure.java.io
+                             clojure.pprint
+                             clojure.stacktrace
+                             clojure.test
+                             clojure.tools.analyzer.ast
+                             clojure.tools.namespace.parse
+                             ;; please don't add `clojure.tools.namespace.repl` here, see comment above.
+                             clojure.tools.nrepl.middleware
+                             clojure.tools.nrepl.misc
+                             nrepl.middleware
+                             nrepl.middleware.interruptible-eval
+                             nrepl.misc
+                             orchard.info
+                             refactor-nrepl.client
+                             refactor-nrepl.config
+                             refactor-nrepl.core
+                             refactor-nrepl.find.find-macros
+                             refactor-nrepl.find.find-symbol
+                             refactor-nrepl.ns.clean-ns
+                             refactor-nrepl.ns.libspecs
+                             refactor-nrepl.ns.ns-parser
+                             refactor-nrepl.ns.pprint
+                             refactor-nrepl.ns.prune-dependencies
+                             refactor-nrepl.ns.rebuild
+                             refactor-nrepl.ns.resolve-missing-test
+                             refactor-nrepl.ns.slam.hound.future
+                             refactor-nrepl.stubs-for-interface
+                             refactor-nrepl.unreadable-files
+                             refactor-nrepl.util]}
+           :consistent-alias     {:aliases {clojure.tools.namespace.dependency dep
+                                            clojure.tools.namespace.file       file
+                                            ;; don't alias as `repl`, because we use this ns mainly for its `refresh-dirs`
+                                            ;; which has little to do with repls:
+                                            clojure.tools.namespace.repl       tools.namespace.repl
+                                            clojure.tools.namespace.track      tracker}}
+           :unresolved-symbol    {:exclude [(refactor-nrepl.ns.ns-parser/with-libspecs-from [libspecs])
+                                            (refactor-nrepl.middleware/set-descriptor! [set-descriptor!])]}
            :unresolved-namespace {:exclude [clojure.main]}}}

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 VERSION ?= 1.10
 
 .inline-deps:
+	git clean -fdx
 	lein with-profile -user,+$(VERSION) inline-deps
 	touch .inline-deps
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@
 
 VERSION ?= 1.10
 
-.inline-deps:
-	git clean -fdx
+clean:
+	lein clean
+	rm -f .inline-deps
+
+.inline-deps: clean
 	lein with-profile -user,+$(VERSION) inline-deps
 	touch .inline-deps
 
@@ -37,6 +40,5 @@ release:
 deploy: .inline-deps
 	lein with-profile -user,+$(VERSION),+plugin.mranderson/config,+lein-plugin deploy clojars
 
-clean:
-	lein clean
-	rm -f .inline-deps
+install: .inline-deps
+	lein with-profile -user,+$(VERSION),+plugin.mranderson/config,+lein-plugin install

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject refactor-nrepl "3.0.0-alpha1"
+(defproject refactor-nrepl "3.0.0-alpha4"
   :description "nREPL middleware to support editor-agnostic refactoring"
   :url "http://github.com/clojure-emacs/refactor-nrepl"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject refactor-nrepl "3.0.0-alpha4"
+(defproject refactor-nrepl "3.0.0-alpha10"
   :description "nREPL middleware to support editor-agnostic refactoring"
   :url "http://github.com/clojure-emacs/refactor-nrepl"
   :license {:name "Eclipse Public License"

--- a/src/refactor_nrepl/ns/tracker.clj
+++ b/src/refactor_nrepl/ns/tracker.clj
@@ -4,7 +4,7 @@
             [clojure.tools.namespace
              [dependency :as dep]
              [file :as file]
-             [repl :refer [refresh-dirs]]
+             [repl :as tools.namespace.repl]
              [track :as tracker]]
             [refactor-nrepl.core :as core]
             [refactor-nrepl.util :as util]
@@ -35,7 +35,7 @@
               resolve
               deref)
       ;; corner case - use the mranderson-ized refresh-dirs (for supporting this project's test suite):
-      refresh-dirs))
+      tools.namespace.repl/refresh-dirs))
 
 (def default-file-filter-predicate (every-pred core/source-file?
                                                safe-for-clojure-tools-namespace?))
@@ -90,8 +90,9 @@
   ([]
    (project-files-in-topo-order false))
   ([ignore-errors?]
-   (let [tracker (build-tracker (util/with-suppressed-errors
-                                  (every-pred (partial in-refresh-dirs? refresh-dirs (absolutize-refresh-dirs user-refresh-dirs))
+   (let [refresh-dirs (user-refresh-dirs)
+         tracker (build-tracker (util/with-suppressed-errors
+                                  (every-pred (partial in-refresh-dirs? refresh-dirs (absolutize-refresh-dirs refresh-dirs))
                                               core/clj-file?)
                                   ignore-errors?))
          nses (dep/topo-sort (:clojure.tools.namespace.track/deps tracker))

--- a/src/refactor_nrepl/ns/tracker.clj
+++ b/src/refactor_nrepl/ns/tracker.clj
@@ -60,8 +60,8 @@
                      (deps-set ns))]
       file)))
 
-(defn- absolutize-refresh-dirs [refresh-dirs]
-  (->> refresh-dirs
+(defn- absolutize-dirs [dirs]
+  (->> dirs
        (map (fn [^String s]
               (File. s)))
        (filter (fn [^File f]
@@ -92,7 +92,7 @@
   ([ignore-errors?]
    (let [refresh-dirs (user-refresh-dirs)
          tracker (build-tracker (util/with-suppressed-errors
-                                  (every-pred (partial in-refresh-dirs? refresh-dirs (absolutize-refresh-dirs refresh-dirs))
+                                  (every-pred (partial in-refresh-dirs? refresh-dirs (absolutize-dirs refresh-dirs))
                                               core/clj-file?)
                                   ignore-errors?))
          nses (dep/topo-sort (:clojure.tools.namespace.track/deps tracker))

--- a/test/refactor_nrepl/ns/tracker_test.clj
+++ b/test/refactor_nrepl/ns/tracker_test.clj
@@ -6,7 +6,7 @@
 (deftest in-refresh-dirs?
   (are [refresh-dirs file-ns expected] (= expected
                                           (sut/in-refresh-dirs? refresh-dirs
-                                                                (#'sut/absolutize-refresh-dirs refresh-dirs)
+                                                                (#'sut/absolutize-dirs refresh-dirs)
                                                                 file-ns))
     ;; if the refresh dirs are unset, we return `true` no matter what:
     []       "src/refactor_nrepl/ns/tracker.clj"       true

--- a/test/refactor_nrepl/ns/tracker_test.clj
+++ b/test/refactor_nrepl/ns/tracker_test.clj
@@ -1,7 +1,7 @@
 (ns refactor-nrepl.ns.tracker-test
   (:require
    [refactor-nrepl.ns.tracker :as sut]
-   [clojure.test :refer [are deftest]]))
+   [clojure.test :refer [are deftest is]]))
 
 (deftest in-refresh-dirs?
   (are [refresh-dirs file-ns expected] (= expected
@@ -18,3 +18,8 @@
     ["src"]  "/"                                       false
     ["ffff"] "src/refactor_nrepl/ns/tracker.clj"       false
     ["src"]  "src/refactor_nrepl/ns/trackeeeeeer.clj"  false))
+
+(deftest project-files-in-topo-order
+  (is (seq (sut/project-files-in-topo-order false))
+      "Does not throw exceptions even when specifying to not ignore errors,
+i.e. it doesn't have bugs"))

--- a/test/refactor_nrepl/ns/tracker_test.clj
+++ b/test/refactor_nrepl/ns/tracker_test.clj
@@ -1,0 +1,20 @@
+(ns refactor-nrepl.ns.tracker-test
+  (:require
+   [refactor-nrepl.ns.tracker :as sut]
+   [clojure.test :refer [are deftest]]))
+
+(deftest in-refresh-dirs?
+  (are [refresh-dirs file-ns expected] (= expected
+                                          (sut/in-refresh-dirs? refresh-dirs
+                                                                (#'sut/absolutize-refresh-dirs refresh-dirs)
+                                                                file-ns))
+    ;; if the refresh dirs are unset, we return `true` no matter what:
+    []       "src/refactor_nrepl/ns/tracker.clj"       true
+
+    ["src"]  "src/refactor_nrepl/ns/tracker.clj"       true
+    ["src"]  "test/refactor_nrepl/ns/tracker_test.clj" false
+    ["test"] "test/refactor_nrepl/ns/tracker_test.clj" true
+    ["src"]  "project.clj"                             false
+    ["src"]  "/"                                       false
+    ["ffff"] "src/refactor_nrepl/ns/tracker.clj"       false
+    ["src"]  "src/refactor_nrepl/ns/trackeeeeeer.clj"  false))


### PR DESCRIPTION
`#(str/starts-with? % file-as-absolute-paths)` was invoking the arguments in the wrong order

As a postmortem, sometimes we use defn privacy as a hatch for skipping the authoring of deftests, here it turned out to be too much of an important feature to skip coverage.

While I was there, I also optimized things as bit by absolutizing the refresh-dirs names less redundantly.