### PR TITLE
Restore tools.nrepl compatibility

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,5 @@
 ;; `nrepl.core/code` can contain intentionally broken code in the test suite, so we silence related resolution errors:
 {:lint-as {nrepl.core/code clojure.core/quote}
- :linters {:unresolved-symbol {:exclude [(refactor-nrepl.ns.ns-parser/with-libspecs-from [libspecs])]}
+ :linters {:unresolved-symbol {:exclude [(refactor-nrepl.ns.ns-parser/with-libspecs-from [libspecs])
+                                         (refactor-nrepl.middleware/set-descriptor! [set-descriptor!])]}
            :unresolved-namespace {:exclude [clojure.main]}}}

--- a/src/refactor_nrepl/middleware.clj
+++ b/src/refactor_nrepl/middleware.clj
@@ -5,10 +5,27 @@
             [refactor-nrepl.core :as core]
             [refactor-nrepl.ns.libspecs :refer [namespace-aliases]]
             [refactor-nrepl.stubs-for-interface :refer [stubs-for-interface]]
-            [clojure.walk :as walk]
-            [nrepl.middleware :refer [set-descriptor!]]
-            [nrepl.misc :refer [response-for]]
-            [nrepl.transport :as transport]))
+            [clojure.walk :as walk]))
+
+;; Compatibility with the legacy tools.nrepl.
+;; It is not recommended to use the legacy tools.nrepl,
+;; therefore it is guarded with a system property.
+;; Specifically, we don't want to require it by chance.
+(when-not (resolve 'set-descriptor!)
+  (if (and (System/getProperty "refactor-nrepl.internal.try-requiring-tools-nrepl")
+           (try
+             (require 'clojure.tools.nrepl)
+             true
+             (catch Exception _
+               false)))
+    (require
+     '[clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+     '[clojure.tools.nrepl.misc :refer [response-for]]
+     '[clojure.tools.nrepl.transport :as transport])
+    (require
+     '[nrepl.middleware :refer [set-descriptor!]]
+     '[nrepl.misc :refer [response-for]]
+     '[nrepl.transport :as transport])))
 
 (defn- require-and-resolve [sym]
   (locking core/require-lock


### PR DESCRIPTION
Blast from the past...

Personally I keep using tools.nrepl, I want to stop doing that but can't atm.

These changes help me try the refactor-nrepl alphas before they hit a broader public.

This commit reverts 345fd20 with an additional system property for extra caution.