### PR TITLE
`imports-and-refers-analysis`: remove tracking and caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Be aware that this isn't the case if you connect to an already running REPL proc
 Add the following, either in your project's `project.clj`,  or in the `:user` profile found at `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[refactor-nrepl "3.0.0-alpha11"]
+:plugins [[refactor-nrepl "3.0.0-alpha12"]
           [cider/cider-nrepl "0.25.9"]]
 ```
 
@@ -37,7 +37,7 @@ Add the following in `~/.boot/profile.boot`:
 (require 'boot.repl)
 
 (swap! boot.repl/*default-dependencies* conj
-       '[refactor-nrepl "3.0.0-alpha11"]
+       '[refactor-nrepl "3.0.0-alpha12"]
        '[cider/cider-nrepl "0.25.9"])
 
 (swap! boot.repl/*default-middleware* conj

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject refactor-nrepl "3.0.0-alpha11"
+(defproject refactor-nrepl "3.0.0-alpha12"
   :description "nREPL middleware to support editor-agnostic refactoring"
   :url "http://github.com/clojure-emacs/refactor-nrepl"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Tracking was excessively obstrusive (it monkey-patched clojure.repl) and coupled (to nrepl middleware).

Now `symbols->ns-syms` doesn't use caching at all, as it ran in less than 1ms anyway.

Similarly `all-ns-imports` has been removed of any caching. This function was a little more expensive (100ms for a medium-sized project), but parallelizing it brings that cost down to 20ms which seems more than acceptable for an end user.

These changes are backed by `refactor-nrepl.ns.imports-and-refers-analysis-test`.
