### PR TITLE
Make `refactor-nrepl.plugin` available again.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Be aware that this isn't the case if you connect to an already running REPL proc
 Add the following, either in your project's `project.clj`,  or in the `:user` profile found at `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[refactor-nrepl "3.0.0-alpha12"]
+:plugins [[refactor-nrepl "3.0.0-alpha13"]
           [cider/cider-nrepl "0.25.9"]]
 ```
 
@@ -37,7 +37,7 @@ Add the following in `~/.boot/profile.boot`:
 (require 'boot.repl)
 
 (swap! boot.repl/*default-dependencies* conj
-       '[refactor-nrepl "3.0.0-alpha12"]
+       '[refactor-nrepl "3.0.0-alpha13"]
        '[cider/cider-nrepl "0.25.9"])
 
 (swap! boot.repl/*default-middleware* conj

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject refactor-nrepl "3.0.0-alpha12"
+(defproject refactor-nrepl "3.0.0-alpha13"
   :description "nREPL middleware to support editor-agnostic refactoring"
   :url "http://github.com/clojure-emacs/refactor-nrepl"
   :license {:name "Eclipse Public License"

--- a/src/refactor_nrepl/plugin.clj
+++ b/src/refactor_nrepl/plugin.clj
@@ -1,0 +1,54 @@
+(ns refactor-nrepl.plugin
+  (:require
+   [refactor-nrepl.core :as core]
+   [leiningen.core.main :as lein]))
+
+(def ^:private min-clojure-version
+  "1.7.0")
+
+(defn- find-clojure-version [dependencies]
+  (->> dependencies
+       (some (fn [[id version & _]]
+               (when (= id 'org.clojure/clojure)
+                 version)))))
+
+(defn- enable-middleware-if-clj-version-ok
+  [{:keys [dependencies managed-dependencies exclusions] :as project}]
+  (let [clojure-excluded? (some #(= % 'org.clojure/clojure) exclusions)
+        clojure-version (when-not clojure-excluded?
+                          (or (find-clojure-version dependencies)
+                              (find-clojure-version managed-dependencies)))
+        clojure-version-ok?
+        (cond clojure-excluded? true ; up to the user
+
+              (nil? clojure-version)
+              ;; Lein 2.5.2+ uses Clojure 1.7 by default
+              (lein/version-satisfies? (lein/leiningen-version) "2.5.2")
+
+              :else
+              (lein/version-satisfies? clojure-version min-clojure-version))]
+    (if clojure-version-ok?
+      (-> project
+          (update-in [:dependencies]
+                     (fnil into [])
+                     [['refactor-nrepl (core/version)]])
+          (update-in [:repl-options :nrepl-middleware]
+                     (fnil into [])
+                     '[refactor-nrepl.middleware/wrap-refactor]))
+      (do
+        (lein/warn "Warning: refactor-nrepl requires Clojure version"
+                   min-clojure-version "or later.")
+        (lein/warn "Warning: refactor-nrepl middleware won't be activated.")
+        project))))
+
+(defn- warn-no-project []
+  (lein/warn "Warning: refactor-nrepl needs to run in the context of a project.")
+  (lein/warn "Warning: refactor-nrepl middleware won't be activated."))
+
+(defn middleware
+  [project]
+  (if (core/project-root)
+    (enable-middleware-if-clj-version-ok project)
+    (do
+      (warn-no-project)
+      project)))


### PR DESCRIPTION
Copies `refactor-nrepl.plugin` as-is from `lein-plugin/refactor_nrepl` to `src/refactor_nrepl`

It turned out, mranderson seemingly supports only one entry for `:source-paths`, so extra entries would be silently dropped, making the plugin unavailable in .jar releases.

I've successfully released this as https://clojars.org/refactor-nrepl/versions/3.0.0-alpha13 and got a confirmation that it works for the plugin use case.

Will keep the PR open until I find a solution other than copying the ns.