### PR TITLE
3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 3.0.0 (2021-10-25)
+
 #### Changes
 
 * [(Part of #230)](https://github.com/clojure-emacs/refactor-nrepl/issues/230): Parallelize various functionality

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ release:
 # specified in project.clj to provide a login and password to the
 # artifact repository.
 
+# CLOJARS_USERNAME=$USER CLOJARS_PASSWORD=$(pbpaste) make deploy
 deploy: .inline-deps
 	lein with-profile -user,+$(VERSION),+plugin.mranderson/config deploy clojars
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Be aware that this isn't the case if you connect to an already running REPL proc
 Add the following, either in your project's `project.clj`,  or in the `:user` profile found at `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[refactor-nrepl "3.0.0-alpha13"]
+:plugins [[refactor-nrepl "3.0.0"]
           [cider/cider-nrepl "0.25.9"]]
 ```
 
@@ -37,7 +37,7 @@ Add the following in `~/.boot/profile.boot`:
 (require 'boot.repl)
 
 (swap! boot.repl/*default-dependencies* conj
-       '[refactor-nrepl "3.0.0-alpha13"]
+       '[refactor-nrepl "3.0.0"]
        '[cider/cider-nrepl "0.25.9"])
 
 (swap! boot.repl/*default-middleware* conj

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject refactor-nrepl "3.0.0-alpha13"
+(defproject refactor-nrepl "3.0.0"
   :description "nREPL middleware to support editor-agnostic refactoring"
   :url "http://github.com/clojure-emacs/refactor-nrepl"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
https://clojars.org/refactor-nrepl/versions/3.0.0

Good chance to get rid of the -alpha suffix, apparently it some piece of emacs somewhere doesn't handle it so well (from what I gathered from a shadow-cljs user)