### PR TITLE
Don't avoid 1-element vectors/lists

### DIFF
--- a/src/refactor_nrepl/ns/clean_ns.clj
+++ b/src/refactor_nrepl/ns/clean_ns.clj
@@ -13,14 +13,13 @@
   * Remove any unused referred symbols.
   * Prune, or remove if uneeded, the :rename clause
   * Returns nil when nothing is changed, so the client knows not to do anything."
-  (:require [refactor-nrepl
-             [config :as config]
-             [core :as core]]
-            [refactor-nrepl.ns
-             [ns-parser :as ns-parser]
-             [prune-dependencies :refer [prune-dependencies]]
-             [rebuild :refer [rebuild-ns-form]]]
-            [clojure.java.io :as io]))
+  (:require
+   [clojure.java.io :as io]
+   [refactor-nrepl.config :as config]
+   [refactor-nrepl.core :as core]
+   [refactor-nrepl.ns.ns-parser :as ns-parser]
+   [refactor-nrepl.ns.prune-dependencies :refer [prune-dependencies]]
+   [refactor-nrepl.ns.rebuild :refer [rebuild-ns-form]]))
 
 (defn- assert-no-exclude-clause
   [use-form]
@@ -35,7 +34,9 @@
   (assert-no-exclude-clause (core/get-ns-component ns-form :use))
   ns-form)
 
-(defn clean-ns [{:keys [path relative-path]}]
+(defn clean-ns
+  "Returns nil if there's nothing to clean."
+  [{:keys [path relative-path]}]
   (let [path (some (fn [p]
                      (when (and p (.exists (io/file p)))
                        p))

--- a/test-resources/cljcns_cleaned.cljc
+++ b/test-resources/cljcns_cleaned.cljc
@@ -3,22 +3,22 @@
   {:author "Winnie the pooh"}
   (:refer-clojure :exclude [macroexpand-1 read read-string])
   #?@(:clj
-      [(:require clojure.data clojure.edn
+      [(:require [clojure.data] [clojure.edn]
                  [clojure.instant :as inst :reload true]
                  [clojure.pprint :refer [cl-format formatter get-pretty-writer]]
                  [clojure.string :refer :all :reload-all true]
                  [clojure.test :refer :all]
-                 clojure.test.junit
+                 [clojure.test.junit]
                  [clojure.walk :refer [postwalk prewalk]]
-                 clojure.xml)
-       (:import [java.io Closeable FilenameFilter PushbackReader]
-                [java.util Calendar Date Random])]
+                 [clojure.xml])
+       (:import (java.io Closeable FilenameFilter PushbackReader)
+                (java.util Calendar Date Random))]
       :cljs
       [(:require [cljs.pprint :as pprint]
                  [cljs.test :refer-macros [deftest is]]
                  [clojure.set :as set]
                  [clojure.string :refer [join split-lines]])
-       (:require-macros cljs.analyzer.api
+       (:require-macros [cljs.analyzer.api]
                         [cljs.analyzer.macros :as am]
                         [cljs.test :refer [run-tests testing]])
-       (:import goog.string)]))
+       (:import (goog string))]))

--- a/test-resources/cljsns_cleaned.cljs
+++ b/test-resources/cljsns_cleaned.cljs
@@ -1,12 +1,12 @@
 (ns cljsns
   (:require [cljs.pprint :as pprint]
             [cljs.test :refer-macros [deftest is]]
-            cljsjs.js-yaml
+            [cljsjs.js-yaml]
             [clojure.set :as set]
             [clojure.string :refer [join split-lines]]
             [js-literal-ns :as js-literal]
             [keyword-ns :as kw])
-  (:require-macros cljs.analyzer.api
+  (:require-macros [cljs.analyzer.api]
                    [cljs.analyzer.macros :as am]
                    [cljs.test :refer [run-tests testing]])
-  (:import goog.string))
+  (:import (goog string)))

--- a/test-resources/ns1_cleaned_and_pprinted
+++ b/test-resources/ns1_cleaned_and_pprinted
@@ -9,16 +9,16 @@
    :extends java.lang.Exception
    :methods [[binomial [int int] double]])
   (:require
-   clojure.data
-   clojure.edn
+   [clojure.data]
+   [clojure.edn]
    [clojure.instant :as inst :reload true]
    [clojure.pprint :refer [cl-format formatter get-pretty-writer]]
    [clojure.string :refer :all :reload-all true]
    [clojure.test :refer :all]
-   clojure.test.junit
+   [clojure.test.junit]
    [clojure.walk :refer [postwalk prewalk]]
-   clojure.xml)
+   [clojure.xml])
   (:import
-   [java.io Closeable FilenameFilter PushbackReader]
-   [java.util Calendar Date Random]
-   [refactor.nrepl SomeClass$InnerClass$InnerInnerClassOne SomeClass$InnerClass$InnerInnerClassTwo]))
+   (java.io Closeable FilenameFilter PushbackReader)
+   (java.util Calendar Date Random)
+   (refactor.nrepl SomeClass$InnerClass$InnerInnerClassOne SomeClass$InnerClass$InnerInnerClassTwo)))

--- a/test-resources/ns1_cleaned_and_pprinted_prefix_notation
+++ b/test-resources/ns1_cleaned_and_pprinted_prefix_notation
@@ -15,8 +15,8 @@
     [string :refer :all :reload-all true]
     [test :refer :all]
     [walk :refer [postwalk prewalk]]]
-   clojure.test.junit)
+   [clojure.test.junit])
   (:import
-   [java.io Closeable FilenameFilter PushbackReader]
-   [java.util Calendar Date Random]
-   [refactor.nrepl SomeClass$InnerClass$InnerInnerClassOne SomeClass$InnerClass$InnerInnerClassTwo]))
+   (java.io Closeable FilenameFilter PushbackReader)
+   (java.util Calendar Date Random)
+   (refactor.nrepl SomeClass$InnerClass$InnerInnerClassOne SomeClass$InnerClass$InnerInnerClassTwo)))


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/refactor-nrepl/issues/344 / rationale there

Not necessarily for merging right away, before I'd like to know if you agree this is a better default?

Should we also provide an option to fall back?

Personally I wouldn't, there doesn't seem to be a huge rationale for the old behavior other than "make things shorter" which seems very relative when considering consistency with other tools or trends over the last few years.