### PR TITLE
Refinements for `clean-ns`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 * [#344](https://github.com/clojure-emacs/refactor-nrepl/issues/344): make clean-ns's style closer to the [how to ns](https://stuartsierra.com/2016/08/27/how-to-ns) style.
 * [#333](https://github.com/clojure-emacs/refactor-nrepl/issues/333): skip scanning irrelevant directories in more places (as it was already done for various other functionalities). 
-* Stop wrapping around 80 columns when pprinting ns forms.
-  * You can explicitly set the new `print-right-margin` option to 72 if desiring to revert this
+* Introduce `print-right-margin`/`print-miser-width` configuration options, used during `pprint`ing of ns forms.
+  * The default is one that is consistent with refactor-nrepl's traditional behavior.
+  * You can set both to `nil` for disabling line wrapping. 
 * ns form printing: also wrap single-segment namespaces in a vector.
 
 ## 3.0.0 (2021-10-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * [#344](https://github.com/clojure-emacs/refactor-nrepl/issues/344): make clean-ns's style closer to the [how to ns](https://stuartsierra.com/2016/08/27/how-to-ns) style.
 * [#333](https://github.com/clojure-emacs/refactor-nrepl/issues/333): skip scanning irrelevant directories in more places (as it was already done for various other functionalities). 
+* Stop wrapping around 80 columns when pprinting ns forms.
+  * You can explicitly set the new `print-right-margin` option to 72 if desiring to revert this
+* ns form printing: also wrap single-segment namespaces in a vector.
 
 ## 3.0.0 (2021-10-25)
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ clean:
 
 inline-deps: .inline-deps
 
+fast-test: clean
+	lein with-profile -user,+$(VERSION) test
+
 test: .inline-deps
 	lein with-profile -user,+$(VERSION),+plugin.mranderson/config test
 

--- a/src/refactor_nrepl/config.clj
+++ b/src/refactor_nrepl/config.clj
@@ -34,13 +34,24 @@
    :libspec-whitelist ["^cljsjs"]
 
    ;; Regexes matching paths that are to be ignored
-   :ignore-paths []})
+   :ignore-paths []
+
+   ;; Will be forwarded to clojure.pprint/*print-right-margin* when pprinting ns forms.
+   ;; You can set it to nil for disabling line wrapping.
+   ;; See also: :print-miser-width
+   :print-right-margin 72
+
+   ;; Will be forwarded to clojure.pprint/*print-miser-width* when pprinting ns forms.
+   ;; You can set it to nil for disabling line wrapping.
+   ;; See also: :print-right-margin
+   :print-miser-width 40})
 
 (defn opts-from-msg [msg]
   (into {}
         (map (fn [[k v]] (cond
                            (and (string? v) (= v "true")) [k true]
                            (and (string? v) (= v "false")) [k false]
+                           (and (string? v) (= v "nil")) [k nil]
                            :else [k v]))
              (update (select-keys msg (keys *config*))
                      :ignore-paths

--- a/src/refactor_nrepl/ns/pprint.clj
+++ b/src/refactor_nrepl/ns/pprint.clj
@@ -1,7 +1,7 @@
 (ns refactor-nrepl.ns.pprint
   (:require [cljfmt.core :as fmt]
             [clojure
-             [pprint :refer [pprint]]
+             [pprint]
              [string :as str]]
             [refactor-nrepl
              [config :refer [*config*]]
@@ -9,6 +9,16 @@
              [util :as util :refer [replace-last]]])
 
   (:import java.util.regex.Pattern))
+
+(defn pprint
+  "Pretty-prints `x` with custom, configurable overrides over `clojure.pprint`'s settings.
+
+  This way, we try to generate a formatting that is agnostic / decoupled from clojure.pprint,
+  and therefore that other tools can also consistently achieve."
+  [x]
+  (binding [clojure.pprint/*print-miser-width* (:print-miser-width *config*)
+            clojure.pprint/*print-right-margin* (:print-right-margin *config*)]
+    (clojure.pprint/pprint x)))
 
 (defn- libspec-vectors-last [libspecs]
   (vec (concat (remove sequential? libspecs)

--- a/src/refactor_nrepl/ns/rebuild.clj
+++ b/src/refactor_nrepl/ns/rebuild.clj
@@ -145,11 +145,11 @@
                     (flatten (seq flags)))))))
 
 (defn- create-libspec-vectors-without-prefix
-  [libspecs]
+  [libspecs vectorize?]
   (vec
    (for [libspec libspecs]
      (create-libspec (assoc libspec :ns (ns-suffix libspec))
-                     false))))
+                     vectorize?))))
 
 (defn- create-libspec-vectors-with-prefix
   [libspecs]
@@ -164,13 +164,13 @@
     (if-not more
       (create-libspec-vectors-with-prefix [libspec])
       [(into [(ns-prefix (first libspecs))]
-             (create-libspec-vectors-without-prefix libspecs))])))
+             (create-libspec-vectors-without-prefix libspecs false))])))
 
 (defn- create-libspec-vectors
   [libspecs-by-prefix]
   (apply concat (for [[prefix libspecs] libspecs-by-prefix]
                   (if (= prefix :none)
-                    (create-libspec-vectors-without-prefix libspecs)
+                    (create-libspec-vectors-without-prefix libspecs true)
                     (create-prefixed-libspec-vectors libspecs)))))
 
 (defn- build-require-form

--- a/test-resources/cljcns.cljc
+++ b/test-resources/cljcns.cljc
@@ -9,7 +9,8 @@
         (clojure data edn)
         [clojure.pprint :refer [get-pretty-writer formatter cl-format]]
         clojure.test.junit
-        [clojure.xml])
+        [clojure.xml]
+        single-segment-ns)
        (:use clojure.test
              clojure.test
              [clojure.string :rename {replace foo reverse bar} :reload-all true :reload true])
@@ -84,3 +85,5 @@
 
      (proxy [FilenameFilter] []
        (accept [d n] true))))
+
+single-segment-ns/foo

--- a/test-resources/cljcns_cleaned.cljc
+++ b/test-resources/cljcns_cleaned.cljc
@@ -10,7 +10,8 @@
                  [clojure.test :refer :all]
                  [clojure.test.junit]
                  [clojure.walk :refer [postwalk prewalk]]
-                 [clojure.xml])
+                 [clojure.xml]
+                 [single-segment-ns])
        (:import (java.io Closeable FilenameFilter PushbackReader)
                 (java.util Calendar Date Random))]
       :cljs

--- a/test/refactor_nrepl/ns/clean_ns_test.clj
+++ b/test/refactor_nrepl/ns/clean_ns_test.clj
@@ -180,7 +180,8 @@
        (let [actual (config/with-config {:insert-newline-after-require setting}
                       (pprint-ns (with-meta artifact-ns nil)))
              expected (-> filename File. .getAbsolutePath slurp)]
-         (= expected actual))
+         (is (= expected actual))
+         true)
     true  "test-resources/artifacts_pprinted"
     false "test-resources/artifacts_pprinted_traditional_newline"))
 

--- a/test/refactor_nrepl/ns/rebuild_test.clj
+++ b/test/refactor_nrepl/ns/rebuild_test.clj
@@ -11,6 +11,14 @@
                 :cljs           {:require ({:ns clojure.string, :as str, :rename {}})
                                  :import  ()}
                 :source-dialect :cljc}))))
+  (t/testing "single segment namespaces"
+    (t/is (= '((:require [single-segment-ns]))
+             (rebuild/build-cljc-dep-forms
+              '{:clj            {:require ({:ns single-segment-ns :rename {}})
+                                 :import  ()}
+                :cljs           {:require ({:ns single-segment-ns, :rename {}})
+                                 :import  ()}
+                :source-dialect :cljc}))))
   (t/testing "shared :requires *and* :cljs conditionals"
     (t/is (= (list (symbol "#?@") '(:clj
                                     [(:require [clojure.string :as str])]

--- a/test/single_segment_ns.clj
+++ b/test/single_segment_ns.clj
@@ -1,0 +1,3 @@
+(ns single-segment-ns)
+
+(defn foo [])


### PR DESCRIPTION
* Add `fast-test` Makefile task
* Decouple `ns.pprint` from `clojure.pprint` defaults
  * The previous behavior was to wrap around 80 colums. Often teams have a quite more generous column limit (if placing a limit at all), so it's simplest to remain agnostic.
  * An option is introduced for reverting to the previous behavior.
* `ns.rebuild`: also wrap single-segment namespace in a vector
  * An edge case I found out about just now.