### PR TITLE
Make `ns.class-search` more comprehensive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Changes
 
 * [#344](https://github.com/clojure-emacs/refactor-nrepl/issues/344): make clean-ns's style closer to the [how to ns](https://stuartsierra.com/2016/08/27/how-to-ns) style.
-* [#333](https://github.com/clojure-emacs/refactor-nrepl/issues/333): skip scanning irrelevant directories in more places (as it was already done for various other functionalities; this limits ananlysis/refactoring to your source/test paths, skipping other artifacts). 
+* [#333](https://github.com/clojure-emacs/refactor-nrepl/issues/333): skip scanning irrelevant directories in more places (as it was already done for various other functionalities; this limits ananlysis/refactoring to your source/test paths, skipping other artifacts).
+* Make `resolve-missing` able to find even more classes than before. 
 * [#346](https://github.com/clojure-emacs/refactor-nrepl/issues/346): refine the heuristic for ignoring irrelevant dirs (see the above bullet point).
 * Introduce `print-right-margin`/`print-miser-width` configuration options, used during `pprint`ing of ns forms.
   * The default is one that is consistent with refactor-nrepl's traditional behavior.

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "https://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[nrepl "0.9.0-beta3"]
+                 ^:inline-dep [compliment "0.3.12"]
                  ^:inline-dep [http-kit "2.5.3"]
                  ^:inline-dep [org.clojure/data.json "2.3.1"]
                  ^:inline-dep [org.clojure/tools.analyzer.jvm "1.1.0"]

--- a/src/refactor_nrepl/ns/class_search.clj
+++ b/src/refactor_nrepl/ns/class_search.clj
@@ -1,124 +1,17 @@
-;;;; Copied from slamhound 1.5.5
-;;;; Copyright © 2011-2012 Phil Hagelberg and contributors
-;;;; Distributed under the Eclipse Public License, the same as Clojure.
 (ns refactor-nrepl.ns.class-search
   "Search the classpath for classes.
 
   Formerly known as `refactor-nrepl.ns.slam.hound.search`."
   (:require
-   [clojure.java.io :refer [file]]
    [clojure.string :as string]
-   [refactor-nrepl.util :as util])
-  (:import
-   (java.io File FilenameFilter)
-   (java.util StringTokenizer)
-   (java.util.jar JarEntry JarFile)
-   (java.util.regex Pattern)))
-
-(defn jar? [^File f]
-  (and (.isFile f) (.endsWith (.getName f) ".jar")))
-
-(defn class-file? [^String path]
-  (.endsWith path ".class"))
-
-(defn clojure-fn-file? [^String file]
-  ;; originally this logic was: (re-find #"\$.*__\d+\.class" f)
-  ;; however that doesn't cover e.g. "clojure/spec/alpha$double_in.class"
-  ;; so we mimic the logic that e.g. Compliment has:
-  (or (.contains file "__")
-      (.contains file "$")))
-
-(defn clojure-ns-file? [^String path]
-  (.endsWith path "__init.class"))
-
-(def jar-filter
-  (proxy [FilenameFilter] []
-    (accept [d n] (jar? (file n)))))
-
-(defn expand-wildcard
-  "Expands a wildcard path entry to its matching .jar files (JDK 1.6+).
-  If not expanding, returns the path entry as a single-element vector."
-  [^String path]
-  (let [f (File. path)]
-    (if (= (.getName f) "*")
-      (.. f getParentFile (list jar-filter))
-      [f])))
-
-(def ^String resource-separator
-  "Please do not use File/separator see e.g. https://git.io/Jzig3"
-  "/")
-
-(defn class-name
-  [^String path]
-  (-> path
-      (.replace ".class" "")
-      (.replace resource-separator ".")))
-
-(defmulti path-class-files
-  (fn [^File f _loc]
-    (cond
-      (.isDirectory f) :dir
-      (jar? f) :jar
-      (class-file? (.getName f)) :class)))
-
-(defmethod path-class-files :default [& _] [])
-
-(defmethod path-class-files :jar
-  ;; Build class info for all jar entry class files.
-  [^File f ^File loc]
-  (let [_lp (.getPath loc)]
-    (try
-      (into ()
-            (comp
-             (map #(.getName ^JarEntry %))
-             (filter class-file?)
-             (remove clojure-fn-file?)
-             (map class-name))
-            (enumeration-seq (.entries (JarFile. f))))
-      (catch Exception e
-        (util/maybe-log-exception e)
-        ;; fail gracefully if jar is unreadable:
-        []))))
-
-(defmethod path-class-files :dir
-  ;; Dispatch directories and files (excluding jars) recursively.
-  [^File d ^File loc]
-  (let [fs (.listFiles d (reify FilenameFilter
-                           (accept [_ dir name]
-                             (-> name file jar? not))))]
-    (into () (mapcat #(path-class-files % loc)) fs)))
-
-(defmethod path-class-files :class
-  ;; Build class info using file path relative to parent classpath entry
-  ;; location. Make sure it decends; a class can't be on classpath directly.
-  [^File f ^File loc]
-  (let [fp (str f)
-        lp (str loc)]
-    (if (re-find (re-pattern (Pattern/quote (str "^" loc))) fp) ; must be descendent of loc
-      (let [fpr (.substring fp (inc (count lp)))]
-        [(class-name fpr)])
-      [])))
-
-(defn path-entries-seq
-  "Split a string on the 'path separator', i.e. ':'. Used for splitting multiple
-  classpath entries."
-  [path-str]
-  (-> path-str
-      (StringTokenizer. File/pathSeparator)
-      enumeration-seq))
+   [compliment.utils]))
 
 (defn- get-available-classes []
-  (into ()
-        (comp (mapcat expand-wildcard)
-              (mapcat (fn [file]
-                        (path-class-files file file)))
-              (remove clojure-fn-file?)
-              (distinct)
-              (map symbol))
-        ;; We use `(System/getProperty "java.class.path")` (at least for the time being) because
-        ;; This code was originally written to handle that string, not a list
-        ;; (this code was broken for a while as `orchard.java.classpath` was being incompatibly used instead)
-        (path-entries-seq (System/getProperty "java.class.path"))))
+  (->> (dissoc (compliment.utils/classes-on-classpath)
+               "")
+       (vals)
+       (reduce into)
+       (mapv symbol)))
 
 (def available-classes
   (delay (get-available-classes)))

--- a/test/refactor_nrepl/ns/class_search_test.clj
+++ b/test/refactor_nrepl/ns/class_search_test.clj
@@ -1,5 +1,6 @@
 (ns refactor-nrepl.ns.class-search-test
   (:require
+   [clojure.string :as string]
    [clojure.test :refer [deftest is]]
    [refactor-nrepl.ns.class-search :as sut]))
 
@@ -13,30 +14,50 @@
 (def non-initializable-classes
   '#{org.mozilla.javascript.SecureCaller})
 
+(defn handle [^Throwable e]
+  (is (or
+       ;; there are only ~5 in ~7922 classes that cause NoClassDefFoundError,
+       ;; see `#'acceptable-error-messages`.
+       ;; They don't have to do with classpath parsing so there's nothing to be fixed:
+       (contains? acceptable-error-messages (.getMessage e))
+       ;; Other internal classes introduced with JDK9:
+       (some (fn [prefix]
+               (-> e
+                   .getMessage
+                   (string/includes? prefix)))
+             ["org.graalvm"
+              "sun."
+              "jdk."]))
+      (-> e (.getMessage)))
+  e)
+
 (defn resolve-class [sym]
   (try
     (Class/forName (str sym)
                    false
                    (-> (Thread/currentThread) .getContextClassLoader))
     (catch NoClassDefFoundError e
-      ;; there are only ~5 in ~7922 classes that cause NoClassDefFoundError,
-      ;; see `#'acceptable-error-messages`.
-      ;; They don't have to do with classpath parsing so there's nothing to be fixed.
-      (is (contains? acceptable-error-messages (.getMessage e))
-          (-> e (.getMessage)))
-      e)
+      (handle e))
+    (catch ClassNotFoundException e
+      (handle e))
     (catch UnsupportedClassVersionError e
       e)))
 
 (defn result-can-be-ignored? [v]
   (or
    (instance? NoClassDefFoundError v)
+   (instance? ClassNotFoundException v)
    (instance? UnsupportedClassVersionError v)
    (contains? non-initializable-classes v)))
 
 (defn ok []
   (is (< 3000 (count @sut/available-classes))
       "There are plenty of completions offered / these's a test corpus")
+
+  (is (some #{'java.nio.channels.FileChannel} @sut/available-classes))
+  (is (some #{'java.io.File} @sut/available-classes))
+  (is (some #{'java.lang.Thread} @sut/available-classes))
+
   (is (< 3000 (count @sut/available-classes-by-last-segment)))
 
   (doseq [x @sut/available-classes


### PR DESCRIPTION
Finds more classes (e.g. `FileChannel`), in all JDKs, without needing an extra .jar (like rt.jar, which I was tempted to add for JDK8 but it's a pretty dubious thing to do) in the classpath to be present.

For this we use Compliment's excellent impl which takes care about cross-JDK compat, and some edge cases e.g. Android: https://github.com/alexander-yakushev/compliment/blob/0e0d3e68c665848522d0b6d1f966920dd10ed7ca/src/compliment/utils.clj

Between manual testing and `refactor-nrepl.ns.class-search-test` I'm confident about these changes.

Finally, while Compliment might not be exactly a class searching API, by mrandersoning this dep we can be sure that this feature will never go away.