### PR TITLE
Disable the extensions performed by `fs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [#355](https://github.com/clojure-emacs/refactor-nrepl/issues/355): Disable the side-effects (as protocol extensions) performed by the `fs` library.
+
 ## 3.1.0 (2021-11-09)
 
 ### Changes

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  ^:inline-dep [org.clojure/tools.reader "1.3.6"]
                  ^:inline-dep [cider/orchard "0.7.3"]
                  ^:inline-dep [cljfmt "0.8.0" :exclusions [rewrite-clj rewrite-cljs]]
-                 ^:inline-dep [clj-commons/fs "1.6.307"]
+                 ^:inline-dep [clj-commons/fs "1.6.310"]
                  ^:inline-dep [rewrite-clj "1.0.699-alpha"]
                  ^:inline-dep [version-clj "1.0.0"]]
   :exclusions [org.clojure/clojure] ; see versions matrix below
@@ -66,7 +66,7 @@
                                           with-debug-bindings [[:inner 0]]
                                           merge-meta [[:inner 0]]
                                           try-if-let [[:block 1]]}}}]
-             :eastwood {:plugins         [[jonase/eastwood "0.9.9"]]
+             :eastwood {:plugins         [[jonase/eastwood "1.0.0"]]
                         :eastwood {;; :implicit-dependencies would fail spuriously when the CI matrix runs for Clojure < 1.10,
                                    ;; because :implicit-dependencies can only work for a certain corner case starting from 1.10.
                                    :exclude-linters [:implicit-dependencies]
@@ -74,7 +74,7 @@
                                    :add-linters [:performance :boxed-math]
                                    :config-files ["eastwood.clj"]}}
              :clj-kondo [:test
-                         {:dependencies [[clj-kondo "2021.10.19"]]}]}
+                         {:dependencies [[clj-kondo "2021.12.01"]]}]}
 
   :jvm-opts ~(cond-> []
                (System/getenv "CI")

--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -4,7 +4,6 @@
    [clojure.string :as str]
    [clojure.tools.namespace.parse :as parse]
    [clojure.tools.reader.reader-types :as readers]
-   [me.raynes.fs :as fs]
    [orchard.java.classpath :as cp]
    [orchard.misc :as misc]
    [refactor-nrepl.config :as config]
@@ -12,6 +11,10 @@
    [refactor-nrepl.util :as util :refer [normalize-to-unix-path]])
   (:import
    (java.io File FileReader PushbackReader StringReader)))
+
+;; Require our `fs` customizations before `fs` is loaded:
+(require '[refactor-nrepl.fs])
+(require '[me.raynes.fs :as fs])
 
 (defn version []
   (let [v (-> (or (io/resource "refactor-nrepl/refactor-nrepl/project.clj")

--- a/src/refactor_nrepl/fs.clj
+++ b/src/refactor_nrepl/fs.clj
@@ -1,0 +1,7 @@
+(ns refactor-nrepl.fs
+  "Sets the compile-time feature-flags from the `fs` library.
+  This ns should be `require`d before any other `fs` ns."
+  (:require
+   [me.raynes.fs.feature-flags]))
+
+(alter-var-root #'me.raynes.fs.feature-flags/extend-coercions? (constantly false))

--- a/src/refactor_nrepl/rename_file_or_dir.clj
+++ b/src/refactor_nrepl/rename_file_or_dir.clj
@@ -1,7 +1,6 @@
 (ns refactor-nrepl.rename-file-or-dir
   (:require
    [clojure.string :as str]
-   [me.raynes.fs :as fs]
    [refactor-nrepl.core :as core]
    [refactor-nrepl.ns.ns-parser :as ns-parser]
    [refactor-nrepl.ns.pprint :refer [pprint-ns]]
@@ -12,6 +11,10 @@
    (java.io File)
    (java.nio.file Files)
    (java.util.regex Pattern)))
+
+;; Require our `fs` customizations before `fs` is loaded:
+(require '[refactor-nrepl.fs])
+(require '[me.raynes.fs :as fs])
 
 (declare -rename-file-or-dir)
 

--- a/test/refactor_nrepl/fs_test.clj
+++ b/test/refactor_nrepl/fs_test.clj
@@ -1,0 +1,18 @@
+(ns refactor-nrepl.fs-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is]])
+  (:import
+   (java.io File)))
+
+(require '[refactor-nrepl.fs])
+
+(deftest extensions-are-disabled
+  (is (try
+        (-> "project.clj" File. .toPath io/file)
+        false
+        (catch Exception e
+          (assert (-> e
+                      .getMessage
+                      #{"No implementation of method: :as-file of protocol: #'clojure.java.io/Coercions found for class: sun.nio.fs.UnixPath"}))
+          true))))


### PR DESCRIPTION
These could affect end-users.

Checking out the codebase, we don't ever handle `nio.Path`s so we don't depend on them either.

Uses the flags introduced here: https://github.com/clj-commons/fs/pull/11/files

Fixes https://github.com/clojure-emacs/refactor-nrepl/issues/355