### PR TITLE
Upgrade some deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### Changes
 
-* Upgrade Orchard.
-* Upgrade `tools.analyzer.jvm`.
+* Address minor warnings that could be seen under the Clojure 1.11 series.
+  * Accomplished by upgrading Orchard, and `tools.analyzer.jvm`.
 * [#355](https://github.com/clojure-emacs/refactor-nrepl/issues/355): Disable the side-effects (as protocol extensions) performed by the `fs` library.
 
 ## 3.1.0 (2021-11-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 3.2.0 (2022-01-09)
+
+### Changes
+
+* Upgrade Orchard.
+* Upgrade `tools.analyzer.jvm`.
 * [#355](https://github.com/clojure-emacs/refactor-nrepl/issues/355): Disable the side-effects (as protocol extensions) performed by the `fs` library.
 
 ## 3.1.0 (2021-11-09)

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ release:
 # specified in project.clj to provide a login and password to the
 # artifact repository.
 
-# GIT_TAG=3.2.0 CLOJARS_USERNAME=$USER CLOJARS_PASSWORD=$(pbpaste) make deploy
+# GIT_TAG=v3.2.0 CLOJARS_USERNAME=$USER CLOJARS_PASSWORD=$(pbpaste) make deploy
 deploy: check-env .inline-deps
 	lein with-profile -user,+$(VERSION),+plugin.mranderson/config deploy clojars
 	git tag -a "$$GIT_TAG" -m "$$GIT_TAG"

--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,26 @@ release:
 # specified in project.clj to provide a login and password to the
 # artifact repository.
 
-# CLOJARS_USERNAME=$USER CLOJARS_PASSWORD=$(pbpaste) make deploy
-deploy: .inline-deps
+# GIT_TAG=3.2.0 CLOJARS_USERNAME=$USER CLOJARS_PASSWORD=$(pbpaste) make deploy
+deploy: check-env .inline-deps
 	lein with-profile -user,+$(VERSION),+plugin.mranderson/config deploy clojars
+	git tag -a "$$GIT_TAG" -m "$$GIT_TAG"
+	git push
+	git push --tags
 
 jar: .inline-deps
 	lein with-profile -user,+$(VERSION),+plugin.mranderson/config jar
 
 install: .inline-deps
 	lein with-profile -user,+$(VERSION),+plugin.mranderson/config install
+
+check-env:
+ifndef CLOJARS_USERNAME
+	$(error CLOJARS_USERNAME is undefined)
+endif
+ifndef CLOJARS_PASSWORD
+	$(error CLOJARS_PASSWORD is undefined)
+endif
+ifndef GIT_TAG
+	$(error GIT_TAG is undefined)
+endif

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Be aware that this isn't the case if you connect to an already running REPL proc
 Add the following, either in your project's `project.clj`,  or in the `:user` profile found at `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[refactor-nrepl "3.1.0"]
+:plugins [[refactor-nrepl "3.2.0"]
           [cider/cider-nrepl "0.25.9"]]
 ```
 
@@ -37,7 +37,7 @@ Add the following in `~/.boot/profile.boot`:
 (require 'boot.repl)
 
 (swap! boot.repl/*default-dependencies* conj
-       '[refactor-nrepl "3.1.0"]
+       '[refactor-nrepl "3.2.0"]
        '[cider/cider-nrepl "0.25.9"])
 
 (swap! boot.repl/*default-middleware* conj

--- a/project.clj
+++ b/project.clj
@@ -7,10 +7,10 @@
                  ^:inline-dep [compliment "0.3.12"]
                  ^:inline-dep [http-kit "2.5.3"]
                  ^:inline-dep [org.clojure/data.json "2.3.1"]
-                 ^:inline-dep [org.clojure/tools.analyzer.jvm "1.1.0"]
+                 ^:inline-dep [org.clojure/tools.analyzer.jvm "1.2.2"]
                  ^:inline-dep [org.clojure/tools.namespace "1.1.0" :exclusions [org.clojure/tools.reader]]
                  ^:inline-dep [org.clojure/tools.reader "1.3.6"]
-                 ^:inline-dep [cider/orchard "0.7.3"]
+                 ^:inline-dep [cider/orchard "0.8.0"]
                  ^:inline-dep [cljfmt "0.8.0" :exclusions [rewrite-clj rewrite-cljs]]
                  ^:inline-dep [clj-commons/fs "1.6.310"]
                  ^:inline-dep [rewrite-clj "1.0.699-alpha"]
@@ -38,7 +38,7 @@
                                        [com.google.errorprone/error_prone_annotations "2.1.3"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.2"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
 
              :master {:repositories [["snapshots"
                                       "https://oss.sonatype.org/content/repositories/snapshots"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject refactor-nrepl "3.1.0"
+(defproject refactor-nrepl "3.2.0"
   :description "nREPL middleware to support editor-agnostic refactoring"
   :url "https://github.com/clojure-emacs/refactor-nrepl"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -66,7 +66,7 @@
                                           with-debug-bindings [[:inner 0]]
                                           merge-meta [[:inner 0]]
                                           try-if-let [[:block 1]]}}}]
-             :eastwood {:plugins         [[jonase/eastwood "1.0.0"]]
+             :eastwood {:plugins         [[jonase/eastwood "1.1.0"]]
                         :eastwood {;; :implicit-dependencies would fail spuriously when the CI matrix runs for Clojure < 1.10,
                                    ;; because :implicit-dependencies can only work for a certain corner case starting from 1.10.
                                    :exclude-linters [:implicit-dependencies]
@@ -74,7 +74,7 @@
                                    :add-linters [:performance :boxed-math]
                                    :config-files ["eastwood.clj"]}}
              :clj-kondo [:test
-                         {:dependencies [[clj-kondo "2021.12.01"]]}]}
+                         {:dependencies [[clj-kondo "2021.12.19"]]}]}
 
   :jvm-opts ~(cond-> []
                (System/getenv "CI")


### PR DESCRIPTION
Removes warnings for Clojure 1.11 e.g.:

```
WARNING: update-vals already refers to: #'clojure.core/update-vals in namespace: refactor-nrepl.inlined-deps.orchard.v0v7v3.orchard.misc, being replaced by: #'refactor-nrepl.inlined-deps.orchard.v0v7v3.orchard.misc/update-vals
WARNING: update-vals already refers to: #'clojure.core/update-vals in namespace: refactor-nrepl.inlined-deps.toolsanalyzer.v1v0v0.clojure.tools.analyzer.utils, being replaced by: #'refactor-nrepl.inlined-deps.toolsanalyzer.v1v0v0.clojure.tools.analyzer.utils/update-vals
```
