### PR TITLE
Always use mranderson without parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ executors:
       - image: circleci/clojure:openjdk-8-lein-2.9.1-node
     environment:
       LEIN_ROOT: "true"   # we intended to run lein as root
+      LEIN_JVM_OPTS: -Dmranderson.internal.no-parallelism=true
       JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
     <<: *defaults
 


### PR DESCRIPTION
About 10 or 20% of CI jobs were failing due to parallelism, which meant that one often had to manually restart builds which would delay releases, etc.

CI runtimes aren't much slower:

#### Before

![image](https://user-images.githubusercontent.com/1162994/152979398-eff6b383-a68d-4b1f-a690-b4f08556dc94.png)

#### After

![image](https://user-images.githubusercontent.com/1162994/152979952-3c9429d0-e383-412e-acf5-d21d88c0e8bf.png)
