### PR TITLE
Guard `read-ns-form` against non-existing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [#142](https://github.com/clojure-emacs/refactor-nrepl/issues/142): Guard `read-ns-form` against non-existing files.
+
 ## 3.3.1
 
 * [#363](https://github.com/clojure-emacs/refactor-nrepl/issues/363): Fix a memoization bug in `clean-namespace`.

--- a/project.clj
+++ b/project.clj
@@ -69,7 +69,7 @@
                                           with-debug-bindings [[:inner 0]]
                                           merge-meta [[:inner 0]]
                                           try-if-let [[:block 1]]}}}]
-             :eastwood {:plugins         [[jonase/eastwood "1.1.1"]]
+             :eastwood {:plugins         [[jonase/eastwood "1.2.2"]]
                         :eastwood {;; :implicit-dependencies would fail spuriously when the CI matrix runs for Clojure < 1.10,
                                    ;; because :implicit-dependencies can only work for a certain corner case starting from 1.10.
                                    :exclude-linters [:implicit-dependencies]

--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -155,25 +155,29 @@
    (let [^String path-string (when (string? path)
                                path)
          ^File path-file (when-not path-string
-                           path)]
-     (with-open [file-reader (or (some-> path-string FileReader.)
-                                 (some-> path-file FileReader.))]
-       (try
-         (parse/read-ns-decl (readers/indexing-push-back-reader
-                              (PushbackReader. file-reader)))
-         (catch Exception _ nil)))))
+                           path)
+         ^File file (or path-file (File. path-string))]
+     ;; Check for file existence, because clj-refactor.el or other clients might have bugs:
+     (when (some-> file .exists)
+       (with-open [file-reader (FileReader. file)]
+         (try
+           (parse/read-ns-decl (readers/indexing-push-back-reader
+                                (PushbackReader. file-reader)))
+           (catch Exception _ nil))))))
   ([dialect path]
    (let [^String path-string (when (string? path)
                                path)
          ^File path-file (when-not path-string
-                           path)]
-     (with-open [file-reader (or (some-> path-string FileReader.)
-                                 (some-> path-file FileReader.))]
-       (try
-         (parse/read-ns-decl (readers/indexing-push-back-reader
-                              (PushbackReader. file-reader))
-                             {:read-cond :allow :features #{dialect}})
-         (catch Exception _ nil))))))
+                           path)
+         ^File file (or path-file (File. path-string))]
+     ;; Check for file existence, because clj-refactor.el or other clients might have bugs:
+     (when (some-> file .exists)
+       (with-open [file-reader (FileReader. file)]
+         (try
+           (parse/read-ns-decl (readers/indexing-push-back-reader
+                                (PushbackReader. file-reader))
+                               {:read-cond :allow :features #{dialect}})
+           (catch Exception _ nil)))))))
 
 (defn cljc-extension? [^String path]
   (.endsWith path ".cljc"))

--- a/test/refactor_nrepl/core_test.clj
+++ b/test/refactor_nrepl/core_test.clj
@@ -30,10 +30,13 @@
 
 (deftest test-read-ns-form
   (are [input expected] (testing input
-                          (assert (-> input File. .exists))
+                          (case input
+                            "alkjafas/does_not_exist.clj" (assert (not (-> input File. .exists)))
+                            (assert (-> input File. .exists)))
                           (is (= expected
                                  (sut/read-ns-form input)))
                           true)
+    "alkjafas/does_not_exist.clj"                        nil
     "test-resources/readable_file_incorrect_aliases.clj" nil
     "testproject/src/com/example/one.clj"                '(ns com.example.one
                                                             (:require [com.example.two :as two :refer [foo]]


### PR DESCRIPTION
Fixes #142, which although describes a symlinks issue, isn't necessarily concerned with symlinks. After all, symlinks should just work.

I believe it's clj-refactor.el that sends out invalid requests (specifically, for cleaning files starting with `src/`, whereas a symlinked file does not start with `src/`, in the context of Lein checkouts).

We can observe that any client can request invalid stuff, so it's worth guarding against.

As `deftest test-read-ns-form` shows, it is already expected behavior that `read-ns-form` can occasionally return `nil`, so its signature isn't changed.

I believe a more comprehensive fix would involve making clj-refactor.el resolve symlinks, but these changes also seem useful.