### PR TITLE
Don't prune `require` forms if they are needed for a given `import` to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * [#173](https://github.com/clojure-emacs/refactor-nrepl/issues/173): `rename-file-or-dir`: rename more kinds of constructs in dependent namespaces: namespace-qualified maps, fully-qualified functions, metadata.
+* [#194](https://github.com/clojure-emacs/refactor-nrepl/issues/194): Don't prune `require` forms if they are needed for a given `import` to work.
 
 ## 3.3.1
 

--- a/src/refactor_nrepl/ns/prune_dependencies.clj
+++ b/src/refactor_nrepl/ns/prune_dependencies.clj
@@ -118,7 +118,12 @@
                      (-> pattern re-pattern (re-find ns-name)))
                    (libspec-allowlist/libspec-allowlist)))))
 
-(defn imports->namespaces [imports]
+(defn imports->namespaces
+  "Given a collection of `:import` clauses, returns the set of namespaces denoted by them, as symbols.
+
+  Some of those namespace symbols may not refer to actual namespaces.
+  e.g. a `java.io.File` import would return `java.io`, which isn't a Clojure namespace."
+  [imports]
   (into #{}
         (map (fn [import]
                (-> (if (sequential? import)
@@ -131,7 +136,10 @@
                    symbol)))
         imports))
 
-(defn libspec->namespaces [libspec]
+(defn libspec->namespaces
+  "Given a libspec, returns the namespaces denoted by it (typically one, but possibly multiple,
+  if prefix notation was used), as symbols."
+  [libspec]
   (cond
     (symbol? libspec)
     [libspec]

--- a/test-resources/defines_deftype.clj
+++ b/test-resources/defines_deftype.clj
@@ -1,0 +1,3 @@
+(ns defines-deftype)
+
+(defrecord SomeDefType [])

--- a/test-resources/ns1.clj
+++ b/test-resources/ns1.clj
@@ -14,11 +14,13 @@
    (clojure data edn)
    [clojure.pprint :refer [get-pretty-writer formatter cl-format]]
    clojure.test.junit
-   [clojure.xml])
+   [clojure.xml]
+   [defines-deftype])
   (:use clojure.test
         clojure.test
         [clojure.string :rename {replace foo reverse bar} :reload-all true :reload true])
-  (:import java.util.Random
+  (:import [defines_deftype SomeDefType]
+           java.util.Random
            java.io.PushbackReader
            java.io.PushbackReader
            java.io.FilenameFilter
@@ -29,6 +31,8 @@
             SomeClass$InnerClass$InnerInnerClassTwo
             SomeClass$InnerClass$InnerInnerClassThree]
            (java.util Date Calendar)))
+
+(SomeDefType.)
 
 (defmacro tt [writer]
   (Random.)

--- a/test-resources/ns1_cleaned.clj
+++ b/test-resources/ns1_cleaned.clj
@@ -15,8 +15,10 @@
              [test :refer :all]
              [walk :refer [postwalk prewalk]]
              xml]
-            clojure.test.junit)
+            clojure.test.junit
+            [defines-deftype])
   (:import
+   [defines_deftype SomeDefType]
    [java.io Closeable FilenameFilter PushbackReader]
    [java.util Calendar Date Random]
    [refactor.nrepl

--- a/test-resources/ns1_cleaned_and_pprinted
+++ b/test-resources/ns1_cleaned_and_pprinted
@@ -17,8 +17,10 @@
    [clojure.test :refer :all]
    [clojure.test.junit]
    [clojure.walk :refer [postwalk prewalk]]
-   [clojure.xml])
+   [clojure.xml]
+   [defines-deftype])
   (:import
+   (defines_deftype SomeDefType)
    (java.io Closeable FilenameFilter PushbackReader)
    (java.util Calendar Date Random)
    (refactor.nrepl SomeClass$InnerClass$InnerInnerClassOne SomeClass$InnerClass$InnerInnerClassTwo)))

--- a/test-resources/ns1_cleaned_and_pprinted_prefix_notation
+++ b/test-resources/ns1_cleaned_and_pprinted_prefix_notation
@@ -15,8 +15,10 @@
     [string :refer :all :reload-all true]
     [test :refer :all]
     [walk :refer [postwalk prewalk]]]
-   [clojure.test.junit])
+   [clojure.test.junit]
+   [defines-deftype])
   (:import
+   (defines_deftype SomeDefType)
    (java.io Closeable FilenameFilter PushbackReader)
    (java.util Calendar Date Random)
    (refactor.nrepl SomeClass$InnerClass$InnerInnerClassOne SomeClass$InnerClass$InnerInnerClassTwo)))

--- a/test/refactor_nrepl/ns/prune_dependencies_test.clj
+++ b/test/refactor_nrepl/ns/prune_dependencies_test.clj
@@ -41,7 +41,7 @@
   (are [imports libspec expected] (= expected
                                      (sut/imports-contain-libspec? (sut/imports->namespaces imports)
                                                                    libspec))
-    #_imports             #_libpsec               #_expected
+    #_imports             #_libspec               #_expected
     '[]                   'foo.bar                false
     '[foo.bar.SomeType]   'foo.bar                true
     '[foo_bar.SomeType]   'foo-bar                true

--- a/test/refactor_nrepl/ns/prune_dependencies_test.clj
+++ b/test/refactor_nrepl/ns/prune_dependencies_test.clj
@@ -1,0 +1,62 @@
+(ns refactor-nrepl.ns.prune-dependencies-test
+  (:require
+   [clojure.test :refer [are deftest]]
+   [refactor-nrepl.ns.prune-dependencies :as sut]))
+
+(deftest imports->namespaces
+  (are [input expected] (= expected
+                           (sut/imports->namespaces input))
+    ['java.io.File]              #{'java.io}
+    ['my_ns.File]                #{'my-ns}
+    ['[java.io File]]            #{'java.io}
+    ['[java.io File FileReader]] #{'java.io}
+    ['(java.io File)]            #{'java.io}
+    ['java.io.File
+     'my_ns.File
+     '[java.io File]
+     '(java.io File)]            #{'java.io 'my-ns}))
+
+(deftest libspec->namespaces
+  (are [input expected] (= expected
+                           (sut/libspec->namespaces input))
+    'foo.bar
+    '[foo.bar],
+
+    '[foo.bar]
+    '[foo.bar],
+
+    '[foo.bar :as bar]
+    '[foo.bar],
+
+    '[clojure data edn
+      [instant :as inst :reload true]
+      [pprint :refer [cl-format formatter get-pretty-writer]]
+      [string :refer :all :reload-all true]
+      [test :refer :all]
+      [walk :refer [postwalk prewalk]]
+      xml]
+    '[clojure.data clojure.edn clojure.instant clojure.pprint clojure.string clojure.test clojure.walk clojure.xml]))
+
+(deftest imports-contain-libspec?
+  (are [imports libspec expected] (= expected
+                                     (sut/imports-contain-libspec? (sut/imports->namespaces imports)
+                                                                   libspec))
+    #_imports             #_libpsec               #_expected
+    '[]                   'foo.bar                false
+    '[foo.bar.SomeType]   'foo.bar                true
+    '[foo_bar.SomeType]   'foo-bar                true
+    '[[foo.bar SomeType]] 'foo.bar                true
+    '[[foo_bar SomeType]] 'foo-bar                true
+    '[foo.bar.SomeType]   'foo.baz                false
+    '[]                   '[foo.bar]              false
+    '[foo.bar.SomeType]   '[foo.bar]              true
+    '[foo.bar.SomeType]   '[foo.bar :as f]        true
+    '[[foo.bar SomeType]] '[foo.bar]              true
+    '[[foo_bar SomeType]] '[foo-bar :as f]        true
+    '[foo_bar.SomeType]   '[foo-bar :as f]        true
+    '[[foo_bar SomeType]] '[foo-bar]              true
+    '[[foo_bar SomeType]] '[foo-bar :as f]        true
+    '[foo.bar.SomeType]   '[foo.baz]              false
+    '[clojure.data.Data]  '[clojure data]         true
+    '[clojure.data.Data]  '[clojure [data :as d]] true
+    '[clojure.data.Data]  '[clojure foo]          false))


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/refactor-nrepl/issues/194