### PR TITLE
Expand `deftest replaces-ns-references-in-dependents`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 3.4.0
+
 * [#369](https://github.com/clojure-emacs/refactor-nrepl/issues/369): Implement "suggest" option for the `namespace-aliases` op.
   * This allows end-users to type [Stuart Sierra style](https://stuartsierra.com/2015/05/10/clojure-namespace-aliases) aliases and have them completed, even if this alias wasn't in use anywhere in a given codebase.
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Be aware that this isn't the case if you connect to an already running REPL proc
 Add the following, either in your project's `project.clj`,  or in the `:user` profile found at `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[refactor-nrepl "3.3.2"]
-          [cider/cider-nrepl "0.25.9"]]
+:plugins [[refactor-nrepl "3.4.0"]
+          [cider/cider-nrepl "0.28.3"]]
 ```
 
 ### Embedded nREPL
@@ -360,12 +360,12 @@ If you want to use `mranderson` while developing locally with the REPL, the sour
 
 When you want to release locally to the following:
 
-    PROJECT_VERSION=3.3.2 make install
+    PROJECT_VERSION=3.4.0 make install
 
 And here's how to deploy to Clojars:
 
 ```bash
-git tag -a v3.3.2 -m "3.3.2"
+git tag -a v3.4.0 -m "3.4.0"
 git push --tags
 ```
 

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,0 +1,1 @@
+{:cljdoc/languages ["clj"]}

--- a/project.clj
+++ b/project.clj
@@ -34,8 +34,8 @@
                :unresolved-tree false}
   :filespecs [{:type :bytes :path "refactor-nrepl/refactor-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
   :profiles {;; Clojure versions matrix
-             :provided {:dependencies [[cider/cider-nrepl "0.27.2"]
-                                       [org.clojure/clojure "1.9.0"]
+             :provided {:dependencies [[cider/cider-nrepl "0.28.3"]
+                                       [org.clojure/clojure "1.10.3"]
                                        ;; For satisfying `:pedantic?`:
                                        [com.google.code.findbugs/jsr305 "3.0.2"]
                                        [com.google.errorprone/error_prone_annotations "2.1.3"]]}

--- a/testproject/src/com/move/dependent_ns1.clj
+++ b/testproject/src/com/move/dependent_ns1.clj
@@ -19,6 +19,9 @@
   (let [^com.move.ns_to_be_moved.TypeToBeMoved x (fn-to-be-moved :_)]
     x)
 
+  ;; https://github.com/clojure-emacs/refactor-nrepl/issues/172
+  (partial instance? com.move.ns_to_be_moved.TypeToBeMoved)
+
   (com.move.ns_to_be_moved.TypeToBeMoved. :ok)
 
   (macro-to-be-moved


### PR DESCRIPTION
* Expand `deftest replaces-ns-references-in-dependents`
  * Closes https://github.com/clojure-emacs/refactor-nrepl/issues/172, which was already (inadvertently) fixed in https://github.com/clojure-emacs/refactor-nrepl/pull/365.
* Fix cljdoc build
  * See: https://github.com/clojure-emacs/orchard/issues/150#issuecomment-1058354437
