### PR TITLE
Extract `namespace-aliases-for`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 3.4.1
+
+* Offer `refactor-nrepl.ns.libspecs/namespace-aliases-for` function.
+  * It's basically like `namespace-aliases`, but accepts files rather than dirs as an argument, which can be more flexible for programmatic use.
+
 ## 3.4.0
 
 * [#369](https://github.com/clojure-emacs/refactor-nrepl/issues/369): Implement "suggest" option for the `namespace-aliases` op.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Be aware that this isn't the case if you connect to an already running REPL proc
 Add the following, either in your project's `project.clj`,  or in the `:user` profile found at `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[refactor-nrepl "3.4.0"]
+:plugins [[refactor-nrepl "3.4.1"]
           [cider/cider-nrepl "0.28.3"]]
 ```
 
@@ -360,12 +360,12 @@ If you want to use `mranderson` while developing locally with the REPL, the sour
 
 When you want to release locally to the following:
 
-    PROJECT_VERSION=3.4.0 make install
+    PROJECT_VERSION=3.4.1 make install
 
 And here's how to deploy to Clojars:
 
 ```bash
-git tag -a v3.4.0 -m "3.4.0"
+git tag -a v3.4.1 -m "3.4.1"
 git push --tags
 ```
 


### PR DESCRIPTION
As indicated in an inline comment:

`namespace-aliases-for` was split out from `namespace-aliases`, for a 3rd-party need.

`namespace-aliases-for` is a little more fine-grained, since it accepts files rather than dirs.