### PR TITLE
Revert accidentally-changed `namespace-aliases` error handling default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 3.4.2
+
+* [#373](https://github.com/clojure-emacs/refactor-nrepl/issues/373): revert accidentally-changed `namespace-aliases` error handling default.
+
 ## 3.4.1
 
 * Offer `refactor-nrepl.ns.libspecs/namespace-aliases-for` function.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Be aware that this isn't the case if you connect to an already running REPL proc
 Add the following, either in your project's `project.clj`,  or in the `:user` profile found at `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[refactor-nrepl "3.4.1"]
+:plugins [[refactor-nrepl "3.4.2"]
           [cider/cider-nrepl "0.28.3"]]
 ```
 
@@ -360,12 +360,12 @@ If you want to use `mranderson` while developing locally with the REPL, the sour
 
 When you want to release locally to the following:
 
-    PROJECT_VERSION=3.4.1 make install
+    PROJECT_VERSION=3.4.2 make install
 
 And here's how to deploy to Clojars:
 
 ```bash
-git tag -a v3.4.1 -m "3.4.1"
+git tag -a v3.4.2 -m "3.4.2"
 git push --tags
 ```
 

--- a/src/refactor_nrepl/ns/libspecs.clj
+++ b/src/refactor_nrepl/ns/libspecs.clj
@@ -143,7 +143,7 @@
        include-tentative-aliases? (update :cljs add-tentative-aliases :cljs files ignore-errors?)))))
 
 (defn namespace-aliases-response [{:keys [suggest]}]
-  (namespace-aliases false
+  (namespace-aliases true
                      (core/source-dirs-on-classpath)
                      suggest))
 


### PR DESCRIPTION
In a recent refactoring, I introduced `defn namespace-aliases-response`. It should have passed `true` instead of `false`.

Fixes #373