### PR TITLE
`libspec-in-use-without-refer-all?`: account for `:as-alias` directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 3.5.1
+
+* Refine `:as-alias` detection.
+
 ## 3.5.0
 
 * [#374](https://github.com/clojure-emacs/refactor-nrepl/issues/374): support Clojure 1.11's new `:as-alias` namespace directive. 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Be aware that this isn't the case if you connect to an already running REPL proc
 Add the following, either in your project's `project.clj`,  or in the `:user` profile found at `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[refactor-nrepl "3.5.0"]
+:plugins [[refactor-nrepl "3.5.1"]
           [cider/cider-nrepl "0.28.3"]]
 ```
 
@@ -360,12 +360,12 @@ If you want to use `mranderson` while developing locally with the REPL, the sour
 
 When you want to release locally to the following:
 
-    PROJECT_VERSION=3.5.0 make install
+    PROJECT_VERSION=3.5.1 make install
 
 And here's how to deploy to Clojars:
 
 ```bash
-git tag -a v3.5.0 -m "3.5.0"
+git tag -a v3.5.1 -m "3.5.1"
 git push --tags
 ```
 

--- a/src/refactor_nrepl/ns/prune_dependencies.clj
+++ b/src/refactor_nrepl/ns/prune_dependencies.clj
@@ -21,7 +21,7 @@
   (= (lookup-symbol-ns current-ns symbol-in-file) ns))
 
 (defn- libspec-in-use-without-refer-all?
-  [{:keys [as ns refer refer-macros require-macros]} symbol-in-file]
+  [{:keys [as as-alias ns refer refer-macros require-macros]} symbol-in-file]
   (or
    ;; Used through refer clause
    (and (not= refer :all)
@@ -35,7 +35,8 @@
    ;; Used as a fully qualified symbol
    (.startsWith ^String symbol-in-file (str ns "/"))
    ;; Aliased symbol in use
-   (and as (.startsWith ^String symbol-in-file (str as "/")))))
+   (and as (.startsWith ^String symbol-in-file (str as "/")))
+   (and as-alias (.startsWith ^String symbol-in-file (str as-alias "/")))))
 
 (defn- libspec-in-use-with-rename?
   [{:keys [rename]} symbols-in-file]

--- a/test/refactor_nrepl/ns/prune_dependencies_test.clj
+++ b/test/refactor_nrepl/ns/prune_dependencies_test.clj
@@ -1,7 +1,11 @@
 (ns refactor-nrepl.ns.prune-dependencies-test
   (:require
-   [clojure.test :refer [are deftest]]
+   [clojure.test :refer [are is deftest]]
    [refactor-nrepl.ns.prune-dependencies :as sut]))
+
+(deftest libspec-in-use-without-refer-all?
+  (is      (@#'sut/libspec-in-use-without-refer-all? '{:as-alias foo}  "foo/bar"))
+  (is (not (@#'sut/libspec-in-use-without-refer-all? '{:as-alias quux} "foo/bar"))))
 
 (deftest imports->namespaces
   (are [input expected] (= expected


### PR DESCRIPTION
Slight oversight from the previous feature.

With these changes, clean-ns will work properly.