### PR TITLE
Don't suggest alias fragments with leading number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [#385](https://github.com/clojure-emacs/refactor-nrepl/pull/385): Fix cljr-refactor.el's `cljr-slash` when namespace fragments start with a number.
+
 ## 3.5.4
 
 * [#383](https://github.com/clojure-emacs/refactor-nrepl/issues/383): `prune-dependencies`: increase accuracy for `:cljs`.

--- a/src/refactor_nrepl/ns/suggest_aliases.clj
+++ b/src/refactor_nrepl/ns/suggest_aliases.clj
@@ -1,6 +1,7 @@
 (ns refactor-nrepl.ns.suggest-aliases
   "Suggestion of aliases based on these guidelines: https://stuartsierra.com/2015/05/10/clojure-namespace-aliases"
   (:require
+   [clojure.edn :as edn]
    [clojure.string :as string]))
 
 (defn test-like-ns-name? [ns-sym]
@@ -11,6 +12,14 @@
                    (or (string/starts-with? last-fragment "t-")
                        (string/starts-with? last-fragment "test-")
                        (some #{"test" "unit" "integration" "acceptance" "functional" "generative"} fragments)))))))
+
+(def readable-as-symbol?
+  (memoize
+   (fn [s]
+     (try
+       (symbol? (edn/read-string s))
+       (catch Exception _
+         false)))))
 
 (defn suggested-aliases [namespace-name]
   (let [fragments (-> namespace-name str (string/split #"\."))
@@ -29,8 +38,10 @@
                        (range 1 (inc (count fragments)))
                        (repeat (distinct fragments)))
         v (into {}
-                (map (fn [segments]
-                       [(->> segments (string/join ".") (symbol)),
-                        [namespace-name]]))
+                (keep (fn [segments]
+                        (let [candidate (->> segments (string/join "."))]
+                          (when (readable-as-symbol? candidate)
+                            [(symbol candidate),
+                             [namespace-name]]))))
                 fragments)]
     (dissoc v namespace-name)))

--- a/test/refactor_nrepl/ns/suggest_aliases_test.clj
+++ b/test/refactor_nrepl/ns/suggest_aliases_test.clj
@@ -21,6 +21,25 @@
     'unit.foo   true
     'foo.unit   true))
 
+(deftest readable-as-symbol?
+  (testing "is readable as symbol"
+    (are [input] (sut/readable-as-symbol? input)
+      "test"
+      "a.test"
+      "a-test"
+      "b.a-test"
+      "ok.5<-here"
+      "this:too!#$%&*"))
+
+  (testing "not readable as symbol"
+    (are [input] (not (sut/readable-as-symbol? input))
+      ":kw"
+      "15"
+      "5-bad"
+      "6:nope"
+      ";what"
+      "#yeah")))
+
 (deftest suggested-aliases
   (are [desc input expected] (testing input
                                (is (= expected
@@ -46,4 +65,7 @@
     "Removes redundant bits such as `clj-` and `.core`"
     'clj-a.b.c.core '{c     [clj-a.b.c.core]
                       b.c   [clj-a.b.c.core]
-                      a.b.c [clj-a.b.c.core]}))
+                      a.b.c [clj-a.b.c.core]}
+
+    "Removes fragments that start with a number (in this case: `9d`, `8b.c.9d`), since they aren't valid symbols"
+    'a.8b.c.9d '{c.9d [a.8b.c.9d]}))


### PR DESCRIPTION
Hey there! By pure coincidence, I happened to be investigating a possible bug in `cljr-slash` and `refactor-nrepl.ns.suggest-aliases/suggested-aliases` just as you posted this writeup #384 today, which looks great btw!
I have a project with some namespaces where the last segment starts with a number like `db.migration.005-alter-table`. `suggested-aliases` offers `005-alter-table` as a possible alias, but that's not a valid suggestion since the clojure reader doesn't accept symbols that start with a number. When the nrepl respose is parsed by parseclj, it also correctly rejects that symbol, but that breaks cljr-slash for the entire project.
I put together this little change to remove such invalid symbols from the suggestions, and it's working well for me so far!

- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)

Thanks!
