### PR TITLE
Honor clj-kondo's namespace local configuration

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -49,4 +49,4 @@
  :config-in-ns {;; for integration tests:
                 refactor-nrepl.ns.libspec-allowlist-test
                 {:linters {:unused-namespace {:exclude [really.important
-                                                        another.important*]}}}}}
+                                                        "^another.important*"]}}}}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -48,5 +48,5 @@
 
  :config-in-ns {;; for integration tests:
                 refactor-nrepl.ns.libspec-allowlist-test
-                {:linters {:unused-namespace {:exclude [really.important
-                                                        "^another.important*"]}}}}}
+                {:linters {:unused-namespace {:exclude [from-config-in-ns
+                                                        "^from-config-in-ns.re*"]}}}}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -44,4 +44,9 @@
            :unresolved-var {:exclude [org.httpkit.client/get]}
            ;; for integration tests:
            :unused-namespace {:exclude [sample.unused.namespace
-                                        "more.unused.namespaces*"]}}}
+                                        "more.unused.namespaces*"]}}
+
+ :config-in-ns {;; for integration tests:
+                refactor-nrepl.ns.libspec-allowlist-test
+                {:linters {:unused-namespace {:exclude [really.important
+                                                        another.important*]}}}}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [#387](https://github.com/clojure-emacs/refactor-nrepl/issues/387): extend clj-kondo `:unused-namespace` integration. Now namespace local configuration is also taken into account.
+
 ## 3.5.5
 
 * [#385](https://github.com/clojure-emacs/refactor-nrepl/pull/385): only `suggest-aliases` that are valid symbols. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 * [#387](https://github.com/clojure-emacs/refactor-nrepl/issues/387): extend clj-kondo `:unused-namespace` integration. Now namespace local configuration is also taken into account.
+  `:libspec-whitelist` can be augmented for particular namespace by:
+  * Adding `:unused-namespace` linter configuration under `:config-in-ns` key in clj-kondo's config file. Like so: `:config-in-ns {example.target.ns {:linters {:unused-namespace {:exclude [ns.to.exclude]}}}}`
+  * Adding `:unused-namespace` linter configuration under `:clj-kondo/config` key in metadata or attribute map of namespace. Like so: `(ns example.target.ns {:clj-kondo/config '{:linters {:unused-namespace {:exclude [ns.to.exclude]}}}})`
 
 ## 3.5.5
 

--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -370,8 +370,9 @@
                       (drop 2)
                       (take 2)
                       (some (fn [e] (when (map? e) e))))]
-    {:top-level-meta (merge ns-meta attr-map)
-     :gc-methods-meta (extract-gen-class-methods-meta ns-form)}))
+    {:top-level-meta ns-meta
+     :gc-methods-meta (extract-gen-class-methods-meta ns-form)
+     :attr-map attr-map}))
 
 (defn read-ns-form-with-meta
   "Read the ns form found at PATH.

--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -365,8 +365,12 @@
                     (StringReader.)
                     (PushbackReader.)
                     parse/read-ns-decl)
-        ns-meta (meta (second ns-form))]
-    {:top-level-meta ns-meta
+        ns-meta (meta (second ns-form))
+        attr-map (->> ns-form
+                      (drop 2)
+                      (take 2)
+                      (some (fn [e] (when (map? e) e))))]
+    {:top-level-meta (merge ns-meta attr-map)
      :gc-methods-meta (extract-gen-class-methods-meta ns-form)}))
 
 (defn read-ns-form-with-meta

--- a/src/refactor_nrepl/ns/libspec_allowlist.clj
+++ b/src/refactor_nrepl/ns/libspec_allowlist.clj
@@ -7,10 +7,11 @@
    (java.util.regex Pattern)))
 
 (defn- kondo-excludes [{:keys [ns meta]}]
-  (let [local-config (:clj-kondo/config meta)
+  (let [linter-path [:linters :unused-namespace :exclude]
+        local-config (:clj-kondo/config meta)
         local-config (if (and (seq? local-config) (= 'quote (first local-config)))
-                          (second local-config)
-                          local-config)
+                       (second local-config)
+                       local-config)
         kondo-file (io/file ".clj-kondo" "config.edn")
         config (when (.exists kondo-file)
                  (try
@@ -18,9 +19,9 @@
                    (catch Exception e
                      (when (System/getenv "CI")
                        (throw e)))))]
-    (concat (get-in config [:linters :unused-namespace :exclude])
-            (get-in config [:config-in-ns ns :linters :unused-namespace :exclude])
-            (get-in local-config [:linters :unused-namespace :exclude]))))
+    (reduce into [(get-in config linter-path)
+                  (get-in config (into [:config-in-ns ns] linter-path))
+                  (get-in local-config linter-path)])))
 
 (defn- libspec-allowlist* [current-ns]
   (->> (kondo-excludes current-ns)

--- a/src/refactor_nrepl/ns/ns_parser.clj
+++ b/src/refactor_nrepl/ns/ns_parser.clj
@@ -119,7 +119,7 @@
        (parse-clj-or-cljs-ns path-or-file))
      :ns ns
      ;; Second element can also be a docstring or reference.
-     :meta (->> args (take 2) (some #(if (map? %) % nil)))
+     :meta (->> args (take 2) (some (fn [e] (when (map? e) e))))
      :source-dialect (core/file->dialect path-or-file))))
 
 (def ^:dynamic *read-ns-form-with-meta* core/read-ns-form-with-meta)

--- a/src/refactor_nrepl/ns/ns_parser.clj
+++ b/src/refactor_nrepl/ns/ns_parser.clj
@@ -112,14 +112,13 @@
          (parse-clj-or-cljs-ns path :cljs)))
 
 (defn parse-ns [path-or-file]
-  (let [[_ ns & args] (core/read-ns-form-with-meta path-or-file)]
+  (let [[_ namespace-name :as ns-form] (core/read-ns-form-with-meta path-or-file)]
     (assoc
      (if (core/cljc-file? (io/file path-or-file))
        (parse-cljc-ns path-or-file)
        (parse-clj-or-cljs-ns path-or-file))
-     :ns ns
-     ;; Second element can also be a docstring or reference.
-     :meta (->> args (take 2) (some (fn [e] (when (map? e) e))))
+     :ns namespace-name
+     :meta (:top-level-meta (meta ns-form))
      :source-dialect (core/file->dialect path-or-file))))
 
 (def ^:dynamic *read-ns-form-with-meta* core/read-ns-form-with-meta)

--- a/src/refactor_nrepl/ns/ns_parser.clj
+++ b/src/refactor_nrepl/ns/ns_parser.clj
@@ -112,12 +112,15 @@
          (parse-clj-or-cljs-ns path :cljs)))
 
 (defn parse-ns [path-or-file]
-  (assoc
-   (if (core/cljc-file? (io/file path-or-file))
-     (parse-cljc-ns path-or-file)
-     (parse-clj-or-cljs-ns path-or-file))
-   :ns (second (core/read-ns-form-with-meta path-or-file))
-   :source-dialect (core/file->dialect path-or-file)))
+  (let [[_ ns & args] (core/read-ns-form-with-meta path-or-file)]
+    (assoc
+     (if (core/cljc-file? (io/file path-or-file))
+       (parse-cljc-ns path-or-file)
+       (parse-clj-or-cljs-ns path-or-file))
+     :ns ns
+     ;; Second element can also be a docstring or reference.
+     :meta (->> args (take 2) (some #(if (map? %) % nil)))
+     :source-dialect (core/file->dialect path-or-file))))
 
 (def ^:dynamic *read-ns-form-with-meta* core/read-ns-form-with-meta)
 

--- a/src/refactor_nrepl/ns/ns_parser.clj
+++ b/src/refactor_nrepl/ns/ns_parser.clj
@@ -112,13 +112,15 @@
          (parse-clj-or-cljs-ns path :cljs)))
 
 (defn parse-ns [path-or-file]
-  (let [[_ namespace-name :as ns-form] (core/read-ns-form-with-meta path-or-file)]
+  (let [[_ namespace-name :as ns-form] (core/read-ns-form-with-meta path-or-file)
+        select-metadata (juxt :top-level-meta :attr-map)
+        metadata (-> ns-form meta select-metadata)]
     (assoc
      (if (core/cljc-file? (io/file path-or-file))
        (parse-cljc-ns path-or-file)
        (parse-clj-or-cljs-ns path-or-file))
      :ns namespace-name
-     :meta (:top-level-meta (meta ns-form))
+     :meta (apply merge metadata)
      :source-dialect (core/file->dialect path-or-file))))
 
 (def ^:dynamic *read-ns-form-with-meta* core/read-ns-form-with-meta)

--- a/src/refactor_nrepl/ns/pprint.clj
+++ b/src/refactor_nrepl/ns/pprint.clj
@@ -153,7 +153,7 @@
         forms (cond (and docstring? attrs?) (nthrest more 2)
                     (not (or docstring? attrs?)) more
                     :else (rest more))
-        ns-meta (:top-level-meta (meta ns-form))]
+        ns-meta (apply dissoc (:top-level-meta (meta ns-form)) (keys attrs?))]
     (-> (with-out-str
           (printf "(ns ")
           (when (seq ns-meta) (pprint-meta ns-meta :newlines true))

--- a/src/refactor_nrepl/ns/pprint.clj
+++ b/src/refactor_nrepl/ns/pprint.clj
@@ -153,7 +153,7 @@
         forms (cond (and docstring? attrs?) (nthrest more 2)
                     (not (or docstring? attrs?)) more
                     :else (rest more))
-        ns-meta (apply dissoc (:top-level-meta (meta ns-form)) (keys attrs?))]
+        ns-meta (:top-level-meta (meta ns-form))]
     (-> (with-out-str
           (printf "(ns ")
           (when (seq ns-meta) (pprint-meta ns-meta :newlines true))

--- a/src/refactor_nrepl/ns/prune_dependencies.clj
+++ b/src/refactor_nrepl/ns/prune_dependencies.clj
@@ -124,11 +124,11 @@
 ;; pruned.
 (defn libspec-should-never-be-pruned?
   "Should `libspec` never be pruned away by the `clean-ns` op?"
-  [libspec]
+  [current-ns libspec]
   (let [ns-name (str (:ns libspec))]
     (boolean (some (fn [^String pattern]
                      (-> pattern re-pattern (re-find ns-name)))
-                   (libspec-allowlist/libspec-allowlist)))))
+                   (libspec-allowlist/libspec-allowlist current-ns)))))
 
 (defn imports->namespaces
   "Given a collection of `:import` clauses, returns the set of namespaces denoted by them, as symbols.
@@ -185,7 +185,7 @@
 
 (defn- prune-libspec [symbols-in-file current-ns imports-namespaces libspec]
   (cond
-    (libspec-should-never-be-pruned? libspec)
+    (libspec-should-never-be-pruned? current-ns libspec)
     libspec
 
     (imports-contain-libspec? imports-namespaces (:ns libspec))

--- a/test-resources/ns_with_meta_and_attr_map.clj
+++ b/test-resources/ns_with_meta_and_attr_map.clj
@@ -1,0 +1,2 @@
+(ns ^:foo ^:bar ^{:a 1, :b 2} ns-with-meta-and-attr-map {:c 3, :d 4}
+  (:require [clojure.test :as t]))

--- a/test/refactor_nrepl/core_test.clj
+++ b/test/refactor_nrepl/core_test.clj
@@ -80,10 +80,10 @@
 
 (deftest extract-ns-meta
   (testing "namespace metadata and attr-map are extracted and merged together"
-    (is (= {:a   1
-            :b   2
-            :bar true
-            :foo true
-            :c   3
-            :d   4}
-           (:top-level-meta (sut/extract-ns-meta (slurp "test-resources/ns_with_meta_and_attr_map.clj")))))))
+    (let [ns-meta (sut/extract-ns-meta (slurp "test-resources/ns_with_meta_and_attr_map.clj"))]
+      (is (= {:a   1
+              :b   2
+              :bar true
+              :foo true}
+             (:top-level-meta ns-meta)))
+      (is (= {:c 3, :d 4} (:attr-map ns-meta))))))

--- a/test/refactor_nrepl/core_test.clj
+++ b/test/refactor_nrepl/core_test.clj
@@ -77,3 +77,13 @@
   (testing "`:as-alias` directives are kept"
     (is (= '(ns as-alias (:require [foo :as-alias f]))
            (sut/read-ns-form-with-meta "test-resources/as_alias.clj")))))
+
+(deftest extract-ns-meta
+  (testing "namespace metadata and attr-map are extracted and merged together"
+    (is (= {:a   1
+            :b   2
+            :bar true
+            :foo true
+            :c   3
+            :d   4}
+           (:top-level-meta (sut/extract-ns-meta (slurp "test-resources/ns_with_meta_and_attr_map.clj")))))))

--- a/test/refactor_nrepl/ns/libspec_allowlist_test.clj
+++ b/test/refactor_nrepl/ns/libspec_allowlist_test.clj
@@ -1,8 +1,13 @@
 (ns refactor-nrepl.ns.libspec-allowlist-test
+  {:clj-kondo/config '{:linters {:unused-namespace {:exclude [something.important
+                                                              "something.more.important*"]}}}}
   (:require
    [clojure.test :refer [are deftest is testing]]
    [refactor-nrepl.ns.libspec-allowlist :as sut]
-   [refactor-nrepl.ns.prune-dependencies :as prune-dependencies]))
+   [refactor-nrepl.ns.prune-dependencies :as prune-dependencies]
+   [refactor-nrepl.ns.ns-parser :refer [parse-ns]]))
+
+(def this-ns (parse-ns "test/refactor_nrepl/ns/libspec_allowlist_test.clj"))
 
 (deftest libspec-allowlist-test
   (testing "Takes into account refactor-nrepls own config, and .clj-kondo/config files alike,
@@ -12,26 +17,41 @@ merging their results"
             ;; from our .clj-kondo file - symbols become quoted patterns:
             "^\\Qsample.unused.namespace\\E$"
             ;; from our .clj-kondo file - strings have 'regex' semantics so are kept as-is:
-            "more.unused.namespaces*"]
+            "more.unused.namespaces*"
+            ;; from our .clj-konfo file, namespace local configuration
+            "^\\Qreally.important\\E$"
+            "^\\Qanother.important*\\E$"
+            ;; from attr-map of this ns
+            "^\\Qsomething.important\\E$"
+            "something.more.important*"]
 
-           (sut/libspec-allowlist)))
+           (sut/libspec-allowlist this-ns)))
 
-    (is (every? string? (sut/libspec-allowlist))
+    (is (every? string? (sut/libspec-allowlist nil))
         "Items coming from different sources all have the same class,
 ensuring they will be treated homogeneously by refactor-nrepl")
 
     (testing "`libspec-should-never-be-pruned?` is integrated with clj-kondo logic,
 effecively parsing its config into well-formed regexes"
       (are [input expected] (= expected
-                               (prune-dependencies/libspec-should-never-be-pruned? {:ns input}))
+                               (prune-dependencies/libspec-should-never-be-pruned? this-ns {:ns input}))
         'sample.unused.namespace   true
         'Asample.unused.namespace  false
         'sample.unused.namespaceB  false
         'more.unused.namespaces    true
         'more.unused.namespacessss true
-        'more.unused.namespac      false))
+        'more.unused.namespac      false
+        'really.important          true
+        'really.importante         false
+        'another.important         true
+        'another.importante        true
+        'Banother.important        false
+        'something.important       true
+        'Esomething.important      false
+        'something.more.important  true
+        'something.more.importante true))
 
     (testing "Always returns a sequence, memoized or not"
       (is (seq (sut/with-memoized-libspec-allowlist
-                 (sut/libspec-allowlist))))
-      (is (seq (sut/libspec-allowlist))))))
+                 (sut/libspec-allowlist this-ns))))
+      (is (seq (sut/libspec-allowlist this-ns))))))

--- a/test/refactor_nrepl/ns/libspec_allowlist_test.clj
+++ b/test/refactor_nrepl/ns/libspec_allowlist_test.clj
@@ -20,7 +20,7 @@ merging their results"
             "more.unused.namespaces*"
             ;; from our .clj-konfo file, namespace local configuration
             "^\\Qreally.important\\E$"
-            "^\\Qanother.important*\\E$"
+            "^another.important*"
             ;; from attr-map of this ns
             "^\\Qsomething.important\\E$"
             "something.more.important*"]


### PR DESCRIPTION
> https://github.com/clojure-emacs/refactor-nrepl/issues/387

This PR makes refactor-nrepl honor clj-kondo's namespace-local configuration of `:unused-namespace` linter via config.edn file and also via ns meta when performing `clean-ns` task. I'll fix/add tests if code is fine

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
