### PR TITLE
Updated version.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  ^:inline-dep [cljfmt "0.9.2" :exclusions [rewrite-clj rewrite-cljs]]
                  ^:inline-dep [clj-commons/fs "1.6.310"]
                  ^:inline-dep [rewrite-clj "1.1.47"]
-                 ^:inline-dep [version-clj "1.0.0"]]
+                 ^:inline-dep [version-clj "2.0.2"]]
   :exclusions [org.clojure/clojure] ; see versions matrix below
 
   :pedantic? ~(if (System/getenv "CI")


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
~- [ ] You've added tests (if possible) to cover your change(s)~
- [x] All tests are passing (run `lein do clean, test`)
- [] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
~- [ ] You've updated the changelog (if adding/changing user-visible functionality)~
~- [ ] You've updated the readme (if adding/changing user-visible functionality)~



The project was on version 1.0.0 before update to 2.0.0.

It only uses one function from version-clj in
refactor-nrepl.artifacts/artifact-versions: version-sort.

This is the change that went into that function from version 1.0.0 to 2.0.0:

https://github.com/xsc/version-clj/compare/v1.0.0...v2.0.0#diff-c6b8870bce46e7fe981de278c5a5eb53847fd489211487800632111290202b63R56

No change to the actual function, but that function uses version-compare function, which did have a change, see:

https://github.com/xsc/version-clj/compare/v1.0.0...v2.0.0#diff-c6b8870bce46e7fe981de278c5a5eb53847fd489211487800632111290202b63R23

If you look at this commit:
https://github.com/xsc/version-clj/commit/c05eeb8dffedda072fa41c9210cfc43cd6f1d0fd you'll see that the tests for version-sort & version-compare were added for the release 1.0.0 and were not amended at the latest release 2.0.2.

And finally a pedantic comparison of version 1.0.0 & the current stable release 2.0.2 (which is this commit's update):

https://github.com/xsc/version-clj/compare/v1.0.0...v2.0.2

