### PR TITLE
Updated the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 Before submitting a PR make sure the following things have been done (and denote this
 by checking the relevant checkboxes):
 
-- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
+- [ ] The commits are consistent with our [contribution guidelines](./CONTRIBUTING.md)
 - [ ] You've added tests (if possible) to cover your change(s)
 - [ ] All tests are passing (run `lein do clean, test`)
 - [ ] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)


### PR DESCRIPTION
The link to CONTRIBUTING.md wasn't pointing to the right document within the repo, but would take you to:

https://github.com/clojure-emacs/refactor-nrepl/compare/CONTRIBUTING.md?expand=1

instead, when viewing it on GitHub, within a pull request description.
