### PR TITLE
Decouple :dev :from :test profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,42 +7,44 @@ clean:
 	rm -f .inline-deps
 
 .inline-deps: clean
-	lein with-profile -user,+$(VERSION) inline-deps
+	lein with-profile -user,-dev,+$(VERSION) inline-deps
 	touch .inline-deps
 
 inline-deps: .inline-deps
 
 fast-test: clean
-	lein with-profile -user,+$(VERSION) test
+	lein with-profile -user,-dev,+$(VERSION) test
+
+quick-test: fast-test
 
 test: .inline-deps
-	lein with-profile -user,+$(VERSION),+plugin.mranderson/config test
+	lein with-profile -user,-dev,+$(VERSION),+plugin.mranderson/config test
 
 cljfmt:
-	lein with-profile -user,+$(VERSION),+cljfmt cljfmt check
+	lein with-profile -user,-dev,+$(VERSION),+cljfmt cljfmt check
 
 cljfmt-fix:
-	lein with-profile -user,+$(VERSION),+cljfmt cljfmt fix
+	lein with-profile -user,-dev,+$(VERSION),+cljfmt cljfmt fix
 
 eastwood:
-	lein with-profile -user,+$(VERSION),+deploy,+eastwood eastwood
+	lein with-profile -user,-dev,+$(VERSION),+deploy,+test,+eastwood eastwood
 
 kondo:
-	lein with-profile -dev,+$(VERSION),+clj-kondo run -m clj-kondo.main --lint src test
+	lein with-profile -user,-dev,+$(VERSION),+clj-kondo run -m clj-kondo.main --lint src test
 
 
 # Deployment is performed via CI by creating a git tag prefixed with "v".
 # Please do not deploy locally as it skips various measures (particularly around mranderson).
 deploy: check-env .inline-deps
-	lein with-profile -user,+$(VERSION),+plugin.mranderson/config deploy clojars
+	lein with-profile -user,-dev,+$(VERSION),+plugin.mranderson/config deploy clojars
 
 jar: .inline-deps
-	lein with-profile -user,+$(VERSION),+plugin.mranderson/config jar
+	lein with-profile -user,-dev,+$(VERSION),+plugin.mranderson/config jar
 
 # Usage: PROJECT_VERSION=3.7.1 make install
 # PROJECT_VERSION is needed because it's not computed dynamically
 install: check-install-env .inline-deps
-	 LEIN_JVM_OPTS="-Dmranderson.internal.no-parallelism=true" lein with-profile -user,+$(VERSION),+plugin.mranderson/config install
+	 LEIN_JVM_OPTS="-Dmranderson.internal.no-parallelism=true" lein with-profile -user,-dev,+$(VERSION),+plugin.mranderson/config install
 
 check-env:
 ifndef CLOJARS_USERNAME

--- a/project.clj
+++ b/project.clj
@@ -46,18 +46,16 @@
                                       "https://oss.sonatype.org/content/repositories/snapshots"]]
                       :dependencies [[org.clojure/clojure "1.12.0-master-SNAPSHOT"]
                                      [org.clojure/clojure "1.12.0-master-SNAPSHOT" :classifier "sources"]]}
-
-             :test {:dependencies [[print-foo "1.0.2"]]}
-             :dev {:dependencies [[org.clojure/clojurescript "1.11.60"]
-                                  [org.clojure/core.async "1.6.673" :exclusions [org.clojure/clojure org.clojure/tools.reader]]
-                                  [cider/piggieback "0.5.3"]
-                                  [commons-io/commons-io "2.13.0"]]
-                   :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}
-                   :jvm-opts ["-Dorchard.use-dynapath=false"]
-                   :java-source-paths ["java-test"]
-                   :resource-paths ["test-resources"
-                                    "testproject/src"]
-                   :repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots"]]}
+             :dev {}
+             :test {:dependencies [[cider/piggieback "0.5.3"]
+                                   [org.clojure/clojurescript "1.11.60"]
+                                   [org.clojure/core.async "1.6.673" :exclusions [org.clojure/clojure org.clojure/tools.reader]]
+                                   [commons-io/commons-io "2.13.0"]]
+                    :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}
+                    :jvm-opts ["-Dorchard.use-dynapath=false"]
+                    :resource-paths ["test-resources"
+                                     "testproject/src"]
+                    :java-source-paths ["java-test"]}
              :cljfmt [:test
                       {:plugins [[lein-cljfmt "0.9.2" :exclusions [org.clojure/clojure
                                                                    org.clojure/clojurescript]]]
@@ -76,7 +74,8 @@
                                    :add-linters [:performance :boxed-math]
                                    :config-files ["eastwood.clj"]}}
              :clj-kondo [:test
-                         {:dependencies [[clj-kondo "2022.06.22"]]}]
+                         {:dependencies [[clj-kondo "2022.06.22"]
+                                         [com.fasterxml.jackson.core/jackson-core "2.13.3"]]}]
 
              :deploy {:source-paths [".circleci/deploy"]}}
 


### PR DESCRIPTION
Generally, test suites should be able to run without the :dev profile being activated.