### PR TITLE
Strengthen/refine `resolve-missing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 3.9.0
+
+* [#401](https://github.com/clojure-emacs/refactor-nrepl/issues/401) `resolve-missing` no longer returns the wrong type
+* [#401](https://github.com/clojure-emacs/refactor-nrepl/issues/401) `resolve-missing` no longer returns non- `import`able classes.
+* [#402](https://github.com/clojure-emacs/refactor-nrepl/issues/402) `resolve-missing` now flags with `:already-interned true` the candidates that are already interned into the calling namespace.
+  * This helps clients avoiding the suggestion/insertion of candidates which are redundant
+    * e.g. `+` is already interned, so is `Thread`
+    * same for `:refer`s and `:rename`s
+
 ## 3.8.0
 
 * [#396](https://github.com/clojure-emacs/refactor-nrepl/pull/396) Handle the analyzing and parsing of Clojure code from .cljc files.

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ deploy: check-env .inline-deps
 jar: .inline-deps
 	lein with-profile -user,-dev,+$(VERSION),+plugin.mranderson/config jar
 
-# Usage: PROJECT_VERSION=3.8.0 make install
+# Usage: PROJECT_VERSION=3.9.0 make install
 # PROJECT_VERSION is needed because it's not computed dynamically
 install: check-install-env .inline-deps
 	 LEIN_JVM_OPTS="-Dmranderson.internal.no-parallelism=true" lein with-profile -user,-dev,+$(VERSION),+plugin.mranderson/config install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Be aware that this isn't the case if you connect to an already running REPL proc
 Add the following, either in your project's `project.clj`,  or in the `:user` profile found at `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[refactor-nrepl "3.8.0"]
+:plugins [[refactor-nrepl "3.9.0"]
           [cider/cider-nrepl "0.31.0"]]
 ```
 
@@ -202,11 +202,17 @@ classpath.  This symbol can be qualified, e.g. `walk/postwalk` or
 is a qualified reference to a clojure var and the second a reference
 to a static java method.
 
+The op also now expects (although does not require) `ns`, the current namespace expressed as a string.
+
 The return value `candidates` is a list of `({:name candidate.ns :type :ns} {:name candidate.package :type :type} ...)` where type is in `#{:type :class :ns
-:macro}` so we can branch on the various ways to make the symbol
-available.  `:type` means the symbol resolved to a var created by
-`defrecord` or `deftype`, `:class` is for Java classes but also includes interfaces.  `:macro`
-is only used if the op is called in a cljs context and means the var resolved to macro.
+:macro}` so we can branch on the various ways to make the symbol available.
+
+* `:type` means the symbol resolved to a var created by `defrecord` or `deftype`
+* `:class` is for Java classes but also includes interfaces.
+* `:macro` is only used if the op is called in a cljs context and means the var resolved to macro.
+
+The additional property `:already-interned` (boolean) indicates if the current namespace (as passed as `ns`) already had the given suggested
+interned (e.g.`Thread` and `Object` are interned by default in all JVM clojure namespaces). This helps avoiding the insertion of redundant requires/imports.
 
 ### hotload-dependency
 
@@ -365,7 +371,7 @@ When you want to release locally to the following:
 And here's how to deploy to Clojars:
 
 ```bash
-git tag -a v3.8.0 -m "3.8.0"
+git tag -a v3.9.0 -m "3.9.0"
 git push --tags
 ```
 

--- a/src/refactor_nrepl/ns/class_search.clj
+++ b/src/refactor_nrepl/ns/class_search.clj
@@ -3,15 +3,25 @@
 
   Formerly known as `refactor-nrepl.ns.slam.hound.search`."
   (:require
+   [clojure.java.io :as io]
    [clojure.string :as string]
-   [compliment.utils]))
+   [compliment.utils])
+  (:import
+   (java.io File)))
 
 (defn- get-available-classes []
-  (->> (dissoc (compliment.utils/classes-on-classpath)
-               "")
-       (vals)
-       (reduce into)
-       (mapv symbol)))
+  (let [classes (->> (dissoc (compliment.utils/classes-on-classpath)
+                             "")
+                     (vals)
+                     (reduce into))]
+    (into []
+          (comp (keep (fn [s]
+                        ;; https://github.com/alexander-yakushev/compliment/issues/105
+                        (when (io/resource (-> s (string/replace "." File/separator) (str ".class")))
+                          s)))
+                (distinct)
+                (map symbol))
+          classes)))
 
 (def available-classes
   (delay (get-available-classes)))

--- a/test/refactor_nrepl/ns/imports_and_refers_analysis_test.clj
+++ b/test/refactor_nrepl/ns/imports_and_refers_analysis_test.clj
@@ -4,9 +4,18 @@
    [refactor-nrepl.ns.imports-and-refers-analysis :as sut]))
 
 (deftest works
-  (is (contains? '#{#{java.lang.Thread sun.jvm.hotspot.runtime.Thread}
-                    #{java.lang.Thread}}
-                 (sut/candidates :import 'Thread [] {})))
+
+  (is (= '#{java.lang.Thread}
+         (sut/candidates :import 'Thread [] {})))
+
+  (is (-> (sut/candidates :import 'Thread [] {}) first meta :refactor-nrepl/is-class))
+
+  (is (= '#{java.io.File}
+         (sut/candidates :import 'File [] {})))
+
+  (is (contains? #{'#{com.sun.tools.javac.util.List java.awt.List java.util.List}
+                   '#{com.sun.xml.internal.bind.v2.schemagen.xmlschema.List java.awt.List java.util.List}}
+                 (sut/candidates :import 'List [] {})))
 
   (is (contains? '#{#{clojure.core}
                     #{clojure.core cljs.core}}

--- a/test/refactor_nrepl/ns/resolve_missing_unit_test.clj
+++ b/test/refactor_nrepl/ns/resolve_missing_unit_test.clj
@@ -1,0 +1,53 @@
+(ns refactor-nrepl.ns.resolve-missing-unit-test
+  {:clj-kondo/config {:linters {:unused-namespace    {:level :off}
+                                :refer               {:level :off}
+                                :unused-referred-var {:level :off}}}}
+  (:require
+   [refactor-nrepl.ns.resolve-missing :as sut]
+   [clojure.test :refer [are deftest is testing]]
+   ;; Supports this deftest - note the :refer and :rename
+   [clojure.spec.alpha :refer [int-in inst-in] :rename {inst-in renamed-inst-in}]
+   [clojure.string :as string]))
+
+(defn remove-cljs
+  "Removes cljs members because their presence depends on flaky conditions
+  (piggieback, whether other tests have been run, etc)."
+  [coll]
+  (into []
+        (remove (fn [x]
+                  (-> x :name (string/includes? "cljs"))))
+        coll))
+
+(deftest resolve-missing-unit-test
+  (let [this-ns         (namespace ::_)
+        non-existing-ns (-> (java.util.UUID/randomUUID) str)]
+
+    (are [input expected] (testing input
+                            (is (= expected
+                                   (-> input
+                                       (assoc :refactor-nrepl.internal/force-jvm? true)
+                                       sut/resolve-missing
+                                       read-string
+                                       remove-cljs)))
+                            true)
+      {:symbol "Thread"}                      '[{:name java.lang.Thread, :type :class}]
+      ;; :already-interned returns true for Thread (Clojure interns this class by default):
+      {:symbol "Thread" :ns this-ns}          '[{:name java.lang.Thread, :type :class, :already-interned true}]
+      {:symbol "Thread" :ns non-existing-ns}  '[{:name java.lang.Thread, :type :class}]
+      {:symbol "File"}                        '[{:name java.io.File, :type :class}]
+      ;; :already-interned returns false for File:
+      {:symbol "File" :ns this-ns}            '[{:name java.io.File, :type :class, :already-interned false}]
+      {:symbol "File" :ns non-existing-ns}    '[{:name java.io.File, :type :class}]
+      {:symbol "+"}                           '[{:name clojure.spec.alpha, :type :ns} {:name clojure.core, :type :ns}]
+      ;; :already-interned returns false for spec, true for code:
+      {:symbol "+" :ns this-ns}               '[{:name clojure.spec.alpha, :type :ns, :already-interned false}
+                                                {:name clojure.core, :type :ns, :already-interned true}]
+      {:symbol "+" :ns non-existing-ns}       '[{:name clojure.spec.alpha, :type :ns} {:name clojure.core, :type :ns}]
+      {:symbol "int-in"}                      '[{:name clojure.spec.alpha, :type :ns}]
+      ;; :already-interned returns true for refers:
+      {:symbol "int-in" :ns this-ns}          '[{:name clojure.spec.alpha, :type :ns, :already-interned true}]
+      {:symbol "int-in" :ns non-existing-ns}  '[{:name clojure.spec.alpha, :type :ns}]
+      {:symbol "inst-in"}                     '[{:name clojure.spec.alpha, :type :ns}]
+      ;; :already-interned returns true for refer + rename:
+      {:symbol "inst-in" :ns this-ns}         '[{:name clojure.spec.alpha, :type :ns, :already-interned true}]
+      {:symbol "inst-in" :ns non-existing-ns} '[{:name clojure.spec.alpha, :type :ns}])))


### PR DESCRIPTION
> Fixes #401
> Fixes #402

* `resolve-missing`:
  * no longer returns the wrong `:type`.
  * no longer returns non- `import`able classes.
  * now flags with `:already-interned true` the candidates that are already interned into the calling namespace.