### PR TITLE
Add always-return-ns-form option to clean-ns

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ by checking the relevant checkboxes):
 - [ ] The commits are consistent with our [contribution guidelines](./CONTRIBUTING.md)
 - [ ] You've added tests (if possible) to cover your change(s)
 - [ ] All tests are passing (run `lein do clean, test`)
-- [ ] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
+- [ ] Code inlining with mranderson works and tests pass with inlined code (run `make install` -- takes a long time)
 - [ ] You've updated the changelog (if adding/changing user-visible functionality)
 - [ ] You've updated the readme (if adding/changing user-visible functionality)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add `always-return-ns-form` option to `clean-ns` message
+
 ## 3.9.1
 
 * `suggest-libspecs` op: support collections for `:only` values.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Configuration settings are passed along with each msg, currently the recognized 
  ;; Should `clean-ns` favor prefix forms in the ns macro?
  :prefix-rewriting true
 
+ ;; Should `clean-ns` always return the ns form even if there were no structural changes? Useful for when there would only have been whitespace changes from pretty-printing it again.
+ :always-return-ns-form false
+
  ;; Should `pprint-ns` place a newline after the `:require` and `:import` tokens?
  :insert-newline-after-require true
 

--- a/src/refactor_nrepl/ns/clean_ns.clj
+++ b/src/refactor_nrepl/ns/clean_ns.clj
@@ -35,8 +35,8 @@
   ns-form)
 
 (defn clean-ns
-  "Returns nil if there's nothing to clean."
-  [{:keys [path relative-path]}]
+  "Returns nil if there's nothing to clean unless always-return-ns-form is true."
+  [{:keys [path relative-path always-return-ns-form]}]
   (let [path (some (fn [p]
                      (when (and p (.exists (io/file p)))
                        p))
@@ -56,5 +56,6 @@
             new-ns-form (-> (ns-parser/parse-ns path)
                             deps-preprocessor
                             (rebuild-ns-form ns-form))]
-        (when-not (= ns-form new-ns-form)
+        (when (or always-return-ns-form
+                  (not= ns-form new-ns-form))
           new-ns-form)))))

--- a/test-resources/ns_with_whitespace_changes_only.clj
+++ b/test-resources/ns_with_whitespace_changes_only.clj
@@ -1,0 +1,9 @@
+(ns ns-with-whitespace-changes-only
+
+  (:require   [clojure.string :as  str]
+            [  clojure.walk   :as walk]))
+
+
+
+(defn foo [x]
+  (walk/postwalk (comp vector str/trim str) x))

--- a/test/refactor_nrepl/ns/clean_ns_test.clj
+++ b/test/refactor_nrepl/ns/clean_ns_test.clj
@@ -58,6 +58,8 @@
 (def ns-with-npm-strs (clean-msg "test-resources/ns_with_npm_strs.cljs"))
 (def ns-with-npm-strs-clean (clean-msg "test-resources/ns_with_npm_strs_clean.cljs"))
 
+(def ns-with-whitespace-changes-only (clean-msg "test-resources/ns_with_whitespace_changes_only.clj"))
+
 (deftest combines-requires
   (let [prefix-requires (config/with-config {:prefix-rewriting true}
                           (core/get-ns-component (clean-ns ns2) :require))
@@ -268,6 +270,14 @@
 (deftest npm-string-sorting
   (is (= (pprint-ns (clean-ns ns-with-npm-strs))
          (pprint-ns (read-string (slurp (:path ns-with-npm-strs-clean)))))))
+
+(deftest whitespace-only-changes-are-ignored-by-default
+  (is (nil? (clean-ns ns-with-whitespace-changes-only))))
+
+(deftest whitespace-only-changes-are-considered-when-always-return-ns-form-option-is-true
+  (is (= (read-string (slurp (:path ns-with-whitespace-changes-only)))
+         (clean-ns (assoc ns-with-whitespace-changes-only
+                          :always-return-ns-form true)))))
 
 (core/with-clojure-version->= {:major 1 :minor 11}
   (deftest as-alias


### PR DESCRIPTION
As discussed via Slack earlier today. 

Aside: Looks like the "Code inlining with mranderson" mentioned in the checklist is outdated - there's no `build.sh` (anymore). Instead, I successfully ran `make install` which seems to be equivalent. Maybe this needs to be updated?

- [X] The commits are consistent with our [contribution guidelines](./CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (run `lein do clean, test`)
- [x] Code inlining with mranderson works and tests pass with inlined code (run `./build.sh install` -- takes a long time)
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)