### PR TITLE
Stop depending on Compliment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [#415](https://github.com/clojure-emacs/refactor-nrepl/issues/415): Remove Compliment dependency.
+
 ## 3.11.0 (2025-05-04)
 
 * Use `tools.analyzer.jvm` 1.3.2.

--- a/project.clj
+++ b/project.clj
@@ -7,13 +7,12 @@
   :license {:name "Eclipse Public License"
             :url "https://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[nrepl "1.3.1" :exclusions [org.clojure/clojure]]
-                 ^:inline-dep [compliment "0.7.0"]
                  ^:inline-dep [http-kit "2.5.0"]
                  ^:inline-dep [org.clojure/data.json "2.5.0"]
                  ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.2"]
                  ^:inline-dep [org.clojure/tools.namespace "1.5.0" :exclusions [org.clojure/tools.reader]]
                  ^:inline-dep [org.clojure/tools.reader "1.5.2"]
-                 ^:inline-dep [cider/orchard "0.34.3" :exclusions [org.clojure/clojure]]
+                 ^:inline-dep [cider/orchard "0.35.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [cljfmt "0.9.2" :exclusions [rewrite-clj rewrite-cljs]]
                  ^:inline-dep [clj-commons/fs "1.6.310"]
                  ^:inline-dep [rewrite-clj "1.1.49"]

--- a/src/refactor_nrepl/ns/class_search.clj
+++ b/src/refactor_nrepl/ns/class_search.clj
@@ -4,33 +4,128 @@
   Formerly known as `refactor-nrepl.ns.slam.hound.search`."
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as string]
-   [compliment.utils])
+   [clojure.string :as string])
   (:import
-   (java.io File)))
+   (java.io File)
+   (java.nio.file Files)
+   (java.util.concurrent.locks ReentrantLock)
+   (java.util.function Function Predicate)
+   (java.util.jar JarEntry JarFile)
+   (java.util.stream Collectors)))
 
-(defn- get-available-classes []
-  (let [classes (compliment.utils/classes-on-classpath)]
-    (into []
-          (comp (keep (fn [s]
-                        ;; https://github.com/alexander-yakushev/compliment/issues/105
-                        (when (io/resource (-> s (string/replace "." File/separator) (str ".class")))
-                          s)))
-                (distinct)
-                (map symbol))
-          classes)))
+(def ^:private simple-cache (atom {}))
 
-(def available-classes
-  (delay (get-available-classes)))
+(defn- classpath-strings []
+  (into [] (keep #(System/getProperty %))
+        ["sun.boot.class.path" "java.ext.dirs" "java.class.path"]))
+
+(let [lock (ReentrantLock.)]
+  (defn- recompute-if-classpath-changed [value-fn]
+    (.lock lock)
+    (try (let [cache @simple-cache
+               cp-hash (reduce hash-combine 0 (classpath-strings))
+               same-cp? (= cp-hash (:classpath-hash cache))
+               cached-value (:files-on-classpath cache)]
+           (if (and (some? cached-value) same-cp?)
+             cached-value
+             (let [value (value-fn)]
+               (reset! simple-cache {:classpath-hash cp-hash
+                                     :files-on-classpath value})
+               value)))
+         (finally (.unlock lock)))))
+
+(defn- classpath
+  "Returns a sequence of File objects of the elements on the classpath."
+  []
+  (mapcat #(.split ^String % File/pathSeparator) (classpath-strings)))
+
+(defn- file-seq-nonr
+  "A tree seq on java.io.Files, doesn't resolve symlinked directories to avoid
+  infinite sequence resulting from recursive symlinked directories."
+  [dir]
+  (tree-seq
+   (fn [^File f] (and (.isDirectory f) (not (Files/isSymbolicLink (.toPath f)))))
+   (fn [^File d] (seq (.listFiles d)))
+   dir))
+
+(defn- list-files
+  "Given a path (either a jar file, directory with classes or directory with
+  paths) returns all files under that path."
+  [^String path, scan-jars?]
+  (cond (.endsWith path "/*")
+        (for [^File jar (.listFiles (File. path))
+              :when (.endsWith ^String (.getName jar) ".jar")
+              file (list-files (.getPath jar) scan-jars?)]
+          file)
+
+        (.endsWith path ".jar")
+        (if scan-jars?
+          (try (-> (.stream (JarFile. path))
+                   (.filter (reify Predicate
+                              (test [_ entry]
+                                (not (.isDirectory ^JarEntry entry)))))
+                   (.map (reify Function
+                           (apply [_ entry]
+                             (.getName ^JarEntry entry))))
+                   (.collect (Collectors/toList)))
+               (catch Exception _))
+          ())
+
+        (= path "") ()
+
+        (.exists (File. path))
+        (let [root (File. path)
+              root-path (.toPath root)]
+          (for [^File file (file-seq-nonr root)
+                :when (not (.isDirectory file))]
+            (let [filename (str (.relativize root-path (.toPath file)))]
+              (cond-> filename
+                ;; Replace Windows backslashes with slashes.
+                (not= File/separator "/") (.replace File/separator "/")
+                (.startsWith filename "/") (.substring filename 1)))))))
+
+(defmacro list-jdk9-base-classfiles
+  "Because on JDK9+ the classfiles are stored not in rt.jar on classpath, but in
+  modules, we have to do extra work to extract them."
+  []
+  (when (try (ns-resolve *ns* 'java.lang.module.ModuleFinder) (catch Exception _))
+    `(-> (.findAll (java.lang.module.ModuleFinder/ofSystem))
+         (.stream)
+         (.flatMap (reify Function
+                     (apply [_ mref#]
+                       (.list (.open ^java.lang.module.ModuleReference mref#)))))
+         (.collect (Collectors/toList)))))
+
+(defn- all-files-on-classpath*
+  "Given a list of files on the classpath, returns the list of all files,
+  including those located inside jar files."
+  [classpath]
+  (let [seen (java.util.HashMap.)
+        seen? (fn [x] (.putIfAbsent seen x x))]
+    (-> []
+        (into (comp (map #(list-files % true)) cat (remove seen?)) classpath)
+        (into (remove seen?) (list-jdk9-base-classfiles)))))
+
+(defn- classes-on-classpath* [files]
+  (let [filename->classname
+        (fn [^String file]
+          (when (.endsWith file ".class")
+            (when-not (or (.contains file "__")
+                          (.contains file "$")
+                          (.equals file "module-info.class"))
+              (let [c (-> (subs file 0 (- (.length file) 6)) ;; .class
+                          ;; Resource separator is always / on all OSes.
+                          (.replace "/" "."))]
+                ;; https://github.com/alexander-yakushev/compliment/issues/105
+                (when (io/resource (-> c (string/replace "." File/separator) (str ".class")))
+                  c)))))]
+    (into [] (comp (keep filename->classname) (distinct) (map symbol)) files)))
+
+(defn available-classes []
+  (classes-on-classpath* (all-files-on-classpath* (classpath))))
 
 (defn- get-available-classes-by-last-segment []
-  (group-by #(symbol (peek (string/split (str %) #"\."))) @available-classes))
+  (group-by #(symbol (peek (string/split (str %) #"\."))) (available-classes)))
 
-(def available-classes-by-last-segment
-  (delay (get-available-classes-by-last-segment)))
-
-(defn reset
-  "Reset the cache of classes"
-  []
-  (alter-var-root #'available-classes (constantly (delay (get-available-classes))))
-  (alter-var-root #'available-classes-by-last-segment (constantly (delay (get-available-classes-by-last-segment)))))
+(defn available-classes-by-last-segment []
+  (recompute-if-classpath-changed #(get-available-classes-by-last-segment)))

--- a/src/refactor_nrepl/ns/imports_and_refers_analysis.clj
+++ b/src/refactor_nrepl/ns/imports_and_refers_analysis.clj
@@ -55,5 +55,5 @@
                          (with-meta s
                            {:refactor-nrepl/is-class true})))
                   (reduce into #{} [(ns-import-candidates missing)
-                                    (get @class-search/available-classes-by-last-segment missing)]))
+                                    (get (class-search/available-classes-by-last-segment) missing)]))
     :refer  (get (symbols->ns-syms) missing)))

--- a/test/refactor_nrepl/ns/class_search_test.clj
+++ b/test/refactor_nrepl/ns/class_search_test.clj
@@ -66,22 +66,22 @@
    (contains? non-initializable-classes v)))
 
 (defn ok []
-  (is (< 3000 (count @sut/available-classes))
+  (is (< 3000 (count (sut/available-classes)))
       "There are plenty of completions offered / these's a test corpus")
 
-  (is (some #{'java.nio.channels.FileChannel} @sut/available-classes))
-  (is (some #{'java.io.File} @sut/available-classes))
-  (is (some #{'java.lang.Thread} @sut/available-classes))
+  (is (some #{'java.nio.channels.FileChannel} (sut/available-classes)))
+  (is (some #{'java.io.File} (sut/available-classes)))
+  (is (some #{'java.lang.Thread} (sut/available-classes)))
 
-  (is (< 3000 (count @sut/available-classes-by-last-segment)))
+  (is (< 3000 (count (sut/available-classes-by-last-segment))))
 
-  (doseq [x @sut/available-classes
+  (doseq [x (sut/available-classes)
           :let [v (resolve-class x)]]
     (when-not (result-can-be-ignored? v)
       (is (class? v)
           (pr-str x))))
 
-  (doseq [[suffix classes] @sut/available-classes-by-last-segment]
+  (doseq [[suffix classes] (sut/available-classes-by-last-segment)]
     (is (seq classes))
     (doseq [c classes
             :let [v (resolve-class c)]]
@@ -92,9 +92,7 @@
       (is (-> c str (.endsWith (str suffix))))))
 
   (is (= '[clojure.lang.ExceptionInfo]
-         (get @sut/available-classes-by-last-segment 'ExceptionInfo))))
+         (get (sut/available-classes-by-last-segment) 'ExceptionInfo))))
 
 (deftest works
-  (ok)
-  (sut/reset)
   (ok))


### PR DESCRIPTION
It's only used for finding files on the classpath which comes out of `compliment.utils` namespace. The latter is not really meant for the public use. It's also better to have one fewer dependency. So I've copied the necessary functions into refactor-nrepl.

---

- [x] You've updated the changelog (if adding/changing user-visible functionality)