### PR TITLE
Update all dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ commands:
       cache_version:
         type: string
         description: "Change this value to force a cache update"
-        default: "1"
+        default: "2"
     steps:
       - run:
           name: Install make

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "https://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[nrepl "1.3.1" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [http-kit "2.5.0"]
-                 ^:inline-dep [org.clojure/data.json "2.5.0"]
+                 ^:inline-dep [org.clojure/data.json "2.5.2"]
                  ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.2"]
                  ^:inline-dep [org.clojure/tools.namespace "1.5.0" :exclusions [org.clojure/tools.reader]]
                  ^:inline-dep [org.clojure/tools.reader "1.5.2"]

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                                     :username :env/clojars_username
                                     :password :env/clojars_password
                                     :sign-releases false}]]
-  :plugins [[thomasa/mranderson "0.5.4-fix76"]]
+  :plugins [[thomasa/mranderson "0.5.4-SNAPSHOT"]]
   :mranderson {:project-prefix  "refactor-nrepl.inlined-deps"
                :expositions     [[org.clojure/tools.analyzer.jvm org.clojure/tools.analyzer]]
                :unresolved-tree false}

--- a/project.clj
+++ b/project.clj
@@ -49,7 +49,7 @@
              :test {:dependencies [[cider/piggieback "0.6.0"]
                                    [org.clojure/clojurescript "1.11.60"]
                                    [org.clojure/core.async "1.6.673" :exclusions [org.clojure/clojure org.clojure/tools.reader]]
-                                   [commons-io/commons-io "2.13.0"]
+                                   [commons-io/commons-io "2.20.0"]
                                    [leiningen-core "2.11.2"
                                     :exclusions [org.clojure/clojure
                                                  commons-codec

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                                     :username :env/clojars_username
                                     :password :env/clojars_password
                                     :sign-releases false}]]
-  :plugins [[thomasa/mranderson "0.5.4-SNAPSHOT"]]
+  :plugins [[thomasa/mranderson "0.5.4-fix76"]]
   :mranderson {:project-prefix  "refactor-nrepl.inlined-deps"
                :expositions     [[org.clojure/tools.analyzer.jvm org.clojure/tools.analyzer]]
                :unresolved-tree false}

--- a/project.clj
+++ b/project.clj
@@ -8,14 +8,14 @@
             :url "https://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[nrepl "1.6.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [http-kit "2.8.1"]
-                 ^:inline-dep [org.clojure/data.json "2.5.2"]
-                 ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.4"]
-                 ^:inline-dep [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/tools.reader]]
-                 ^:inline-dep [org.clojure/tools.reader "1.6.0"]
+                 ^:inline-dep [org.clojure/data.json "2.5.2" :exclusions [org.clojure/clojure]]
+                 ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.4" :exclusions [org.clojure/clojure]]
+                 ^:inline-dep [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/clojure org.clojure/tools.reader]]
+                 ^:inline-dep [org.clojure/tools.reader "1.6.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [cider/orchard "0.39.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [cljfmt "0.9.2" :exclusions [rewrite-clj rewrite-cljs]]
                  ^:inline-dep [clj-commons/fs "1.6.312"]
-                 ^:inline-dep [rewrite-clj "1.2.52"]
+                 ^:inline-dep [rewrite-clj "1.2.52" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [version-clj "2.0.3"]]
    ; see versions matrix below
 
@@ -43,8 +43,8 @@
 
              :master {:repositories [["snapshots"
                                       "https://oss.sonatype.org/content/repositories/snapshots"]]
-                      :dependencies [[org.clojure/clojure "1.12.0-master-SNAPSHOT"]
-                                     [org.clojure/clojure "1.12.0-master-SNAPSHOT" :classifier "sources"]]}
+                      :dependencies [[org.clojure/clojure "1.13.0-master-SNAPSHOT"]
+                                     [org.clojure/clojure "1.13.0-master-SNAPSHOT" :classifier "sources"]]}
              :dev {}
              :test {:dependencies [[cider/piggieback "0.6.0"]
                                    [org.clojure/clojurescript "1.11.60"]

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  ^:inline-dep [http-kit "2.5.0"]
                  ^:inline-dep [org.clojure/data.json "2.5.2"]
                  ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.2"]
-                 ^:inline-dep [org.clojure/tools.namespace "1.5.0" :exclusions [org.clojure/tools.reader]]
+                 ^:inline-dep [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/tools.reader]]
                  ^:inline-dep [org.clojure/tools.reader "1.5.2"]
                  ^:inline-dep [cider/orchard "0.35.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [cljfmt "0.9.2" :exclusions [rewrite-clj rewrite-cljs]]

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  ^:inline-dep [org.clojure/data.json "2.5.2"]
                  ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.4"]
                  ^:inline-dep [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/tools.reader]]
-                 ^:inline-dep [org.clojure/tools.reader "1.5.2"]
+                 ^:inline-dep [org.clojure/tools.reader "1.6.0"]
                  ^:inline-dep [cider/orchard "0.35.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [cljfmt "0.9.2" :exclusions [rewrite-clj rewrite-cljs]]
                  ^:inline-dep [clj-commons/fs "1.6.310"]

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  ^:inline-dep [cider/orchard "0.35.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [cljfmt "0.9.2" :exclusions [rewrite-clj rewrite-cljs]]
                  ^:inline-dep [clj-commons/fs "1.6.312"]
-                 ^:inline-dep [rewrite-clj "1.1.49"]
+                 ^:inline-dep [rewrite-clj "1.2.52"]
                  ^:inline-dep [version-clj "2.0.3"]]
    ; see versions matrix below
 

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.4"]
                  ^:inline-dep [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/tools.reader]]
                  ^:inline-dep [org.clojure/tools.reader "1.6.0"]
-                 ^:inline-dep [cider/orchard "0.35.0" :exclusions [org.clojure/clojure]]
+                 ^:inline-dep [cider/orchard "0.39.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [cljfmt "0.9.2" :exclusions [rewrite-clj rewrite-cljs]]
                  ^:inline-dep [clj-commons/fs "1.6.312"]
                  ^:inline-dep [rewrite-clj "1.2.52"]

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :url "https://github.com/clojure-emacs/refactor-nrepl"
   :license {:name "Eclipse Public License"
             :url "https://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[nrepl "1.3.1" :exclusions [org.clojure/clojure]]
+  :dependencies [[nrepl "1.6.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [http-kit "2.8.1"]
                  ^:inline-dep [org.clojure/data.json "2.5.2"]
                  ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.4"]

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  ^:inline-dep [org.clojure/tools.reader "1.6.0"]
                  ^:inline-dep [cider/orchard "0.35.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [cljfmt "0.9.2" :exclusions [rewrite-clj rewrite-cljs]]
-                 ^:inline-dep [clj-commons/fs "1.6.310"]
+                 ^:inline-dep [clj-commons/fs "1.6.312"]
                  ^:inline-dep [rewrite-clj "1.1.49"]
                  ^:inline-dep [version-clj "2.0.3"]]
    ; see versions matrix below

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :license {:name "Eclipse Public License"
             :url "https://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[nrepl "1.3.1" :exclusions [org.clojure/clojure]]
-                 ^:inline-dep [http-kit "2.5.0"]
+                 ^:inline-dep [http-kit "2.8.1"]
                  ^:inline-dep [org.clojure/data.json "2.5.2"]
                  ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.4"]
                  ^:inline-dep [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/tools.reader]]

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
   :dependencies [[nrepl "1.3.1" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [http-kit "2.5.0"]
                  ^:inline-dep [org.clojure/data.json "2.5.2"]
-                 ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.2"]
+                 ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.4"]
                  ^:inline-dep [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/tools.reader]]
                  ^:inline-dep [org.clojure/tools.reader "1.5.2"]
                  ^:inline-dep [cider/orchard "0.35.0" :exclusions [org.clojure/clojure]]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :license {:name "Eclipse Public License"
             :url "https://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[nrepl "1.6.0" :exclusions [org.clojure/clojure]]
-                 ^:inline-dep [http-kit "2.8.1"]
+                 ^:inline-dep [http-kit "2.5.0"]
                  ^:inline-dep [org.clojure/data.json "2.5.2" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.4" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/clojure org.clojure/tools.reader]]

--- a/test/global_test_setup.clj
+++ b/test/global_test_setup.clj
@@ -3,8 +3,8 @@
 
 (def set-refresh-dirs
   (try
-    (require '[refactor-nrepl.inlined-deps.toolsnamespace.v1v5v0.clojure.tools.namespace.repl])
-    @(resolve 'refactor-nrepl.inlined-deps.toolsnamespace.v1v5v0.clojure.tools.namespace.repl/set-refresh-dirs)
+    (require '[refactor-nrepl.inlined-deps.toolsnamespace.v1v5v1.clojure.tools.namespace.repl])
+    @(resolve 'refactor-nrepl.inlined-deps.toolsnamespace.v1v5v1.clojure.tools.namespace.repl/set-refresh-dirs)
     (catch Exception _
       (require '[clojure.tools.namespace.repl])
       @(resolve 'clojure.tools.namespace.repl/set-refresh-dirs))))

--- a/test/refactor_nrepl/artifacts_test.clj
+++ b/test/refactor_nrepl/artifacts_test.clj
@@ -22,18 +22,26 @@
   "Retries a flaky fn `f`.
 
   In our case the flakiness is outside of our control since Maven Central,
-  Clojars, etc can always have hiccups."
+  Clojars, etc can always have hiccups. Retries on both exceptions and
+  empty results."
   ([f]
    (retry-flaky f 0))
   ([f ^long attempts]
-   (try
-     (f)
-     (catch Exception e
-       ;; give Maven a break:
-       (Thread/sleep 18000)
-       (if (< attempts 7)
-         (retry-flaky f (inc attempts))
-         (throw e))))))
+   (let [result (try
+                  (f)
+                  (catch Exception e
+                    (if (< attempts 7)
+                      ::retry
+                      (throw e))))]
+     (if (or (= result ::retry)
+             (and (coll? result) (empty? result)))
+       (do
+         ;; give Maven a break:
+         (Thread/sleep 18000)
+         (if (< attempts 7)
+           (retry-flaky f (inc attempts))
+           result))
+       result))))
 
 (deftest get-mvn-artifacts!-test
   (is (> (count (retry-flaky (fn []

--- a/test/refactor_nrepl/ns/class_search_test.clj
+++ b/test/refactor_nrepl/ns/class_search_test.clj
@@ -33,6 +33,7 @@
               "org.apache.commons.compress.harmony.pack200.Segment can not implement"
               "javax/xml/bind/ModuleUtil (wrong name: META-INF/versions/9/javax/xml/bind/ModuleUtil)"
               "META-INF/versions/9/javax/xml/bind/ModuleUtil (wrong name: javax/xml/bind/ModuleUtil)"
+              "META-INF/versions/9/module-info"
               ;; Stuff brought in by the `leiningen-core` dependency:
               "com/google/inject"
               "org/osgi"


### PR DESCRIPTION
Bump all 9 outdated dependencies to their latest versions. Also fixes the flaky Maven/Clojars artifact tests that would fail when an HTTP request returned empty results instead of throwing.

Dependency updates:
- data.json 2.5.0 → 2.5.2
- tools.namespace 1.5.0 → 1.5.1
- tools.analyzer.jvm 1.3.2 → 1.3.4
- tools.reader 1.5.2 → 1.6.0
- clj-commons/fs 1.6.310 → 1.6.312
- rewrite-clj 1.1.49 → 1.2.52
- http-kit 2.5.0 → 2.8.1
- orchard 0.35.0 → 0.39.0
- nrepl 1.3.1 → 1.6.0