### PR TITLE
Replace Clojure master profile with 1.12 in the CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ jobs:
 #
 # - run tests against the target matrix
 #   - All our defined JDKs
-#   - Clojure 1.10, 1.11, master
+#   - Clojure 1.10, 1.11, 1.12
 # - linter, eastwood and cljfmt
 # - runs code coverage report
 
@@ -217,7 +217,7 @@ workflows:
       - test_code:
           matrix:
             parameters:
-              clojure_version: ["1.10", "1.11", "master"]
+              clojure_version: ["1.10", "1.11", "1.12"]
               jdk_version: [openjdk8, openjdk11, openjdk16, openjdk17]
           filters:
             branches:
@@ -227,7 +227,7 @@ workflows:
       - exercise_code_jarring:
           matrix:
             parameters:
-              clojure_version: ["1.10", "1.11", "master"]
+              clojure_version: ["1.10", "1.11", "1.12"]
               jdk_version: [openjdk8, openjdk11, openjdk16, openjdk17]
           filters:
             branches:

--- a/project.clj
+++ b/project.clj
@@ -39,11 +39,8 @@
                                        [com.google.errorprone/error_prone_annotations "2.20.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :1.11 {:dependencies [[org.clojure/clojure "1.11.1"]]}
+             :1.12 {:dependencies [[org.clojure/clojure "1.12.0"]]}
 
-             :master {:repositories [["snapshots"
-                                      "https://oss.sonatype.org/content/repositories/snapshots"]]
-                      :dependencies [[org.clojure/clojure "1.13.0-master-SNAPSHOT"]
-                                     [org.clojure/clojure "1.13.0-master-SNAPSHOT" :classifier "sources"]]}
              :dev {}
              :test {:dependencies [[cider/piggieback "0.6.0"]
                                    [org.clojure/clojurescript "1.11.60"]


### PR DESCRIPTION
Clojure stopped publishing `master-SNAPSHOT` to `oss.sonatype.org` (the old location) and hasn't reliably published to `central.sonatype.com` either, so the `:master` profile has been producing false-positive CI failures for a while. Sister projects (cider-nrepl, orchard) have already moved to a plain `1.10/1.11/1.12` matrix, so aligning with that.