### PR TITLE
Restore hotload-dependency on top of tools.deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/.eastwood
 /lib
 /classes
 /checkouts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * [#415](https://github.com/clojure-emacs/refactor-nrepl/issues/415): Remove Compliment dependency.
+* [#231](https://github.com/clojure-emacs/refactor-nrepl/issues/231): Restore `hotload-dependency` on top of `clojure.tools.deps`. Also accepts `deps.edn`-style map literals in addition to Leiningen vectors.
 
 ## 3.11.0 (2025-05-04)
 

--- a/README.md
+++ b/README.md
@@ -228,13 +228,13 @@ interned (e.g.`Thread` and `Object` are interned by default in all JVM clojure n
 
 ### hotload-dependency
 
-**Note:** This feature is currently disabled due to Java 10+ compatibility issues.
-
 Loads a new project dependency into the currently active repl.
 
-The op requires `coordinates` which is a leiningen style dependency.
+The op requires `coordinates`, either a Leiningen-style dependency vector (e.g. `[hiccup "2.0.0"]`) or a deps.edn map literal (e.g. `{hiccup {:mvn/version "2.0.0"}}`). Transitive deps are resolved and added.
 
-The return value is a `status` of `done` and `dependency` which is the coordinate vector that was hotloaded, or `error` when something went wrong.
+The return value has `status` of `done` and `dependency` echoing the input coordinates, or `error` when something went wrong.
+
+Implemented on top of `clojure.tools.deps`, so it works under both Leiningen and the Clojure CLI. A `DynamicClassLoader` must be reachable from the calling thread; nREPL provides one by default.
 
 ### find-used-locals
 

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
   :license {:name "Eclipse Public License"
             :url "https://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[nrepl "1.6.0" :exclusions [org.clojure/clojure]]
+                 [org.clojure/tools.deps "0.23.1512" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [org.clojure/data.json "2.5.2" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.4" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/clojure org.clojure/tools.reader]]

--- a/project.clj
+++ b/project.clj
@@ -7,14 +7,16 @@
   :license {:name "Eclipse Public License"
             :url "https://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[nrepl "1.6.0" :exclusions [org.clojure/clojure]]
-                 [org.clojure/tools.deps "0.23.1512" :exclusions [org.clojure/clojure]]
+                 [org.clojure/tools.deps "0.23.1512" :exclusions [org.clojure/clojure
+                                                                  org.clojure/core.async
+                                                                  org.codehaus.plexus/plexus-utils]]
                  ^:inline-dep [org.clojure/data.json "2.5.2" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [org.clojure/tools.analyzer.jvm "1.3.4" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/clojure org.clojure/tools.reader]]
                  ^:inline-dep [org.clojure/tools.reader "1.6.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [cider/orchard "0.39.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [cljfmt "0.9.2" :exclusions [rewrite-clj rewrite-cljs]]
-                 ^:inline-dep [clj-commons/fs "1.6.312"]
+                 ^:inline-dep [clj-commons/fs "1.6.312" :exclusions [org.apache.commons/commons-lang3]]
                  ^:inline-dep [rewrite-clj "1.2.52" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [version-clj "2.0.3"]]
    ; see versions matrix below
@@ -50,7 +52,17 @@
                                    [leiningen-core "2.11.2"
                                     :exclusions [org.clojure/clojure
                                                  commons-codec
-                                                 com.google.code.findbugs/jsr305]]]
+                                                 com.google.code.findbugs/jsr305
+                                                 org.apache.maven.resolver/maven-resolver-api
+                                                 org.apache.maven.resolver/maven-resolver-spi
+                                                 org.apache.maven.resolver/maven-resolver-impl
+                                                 org.apache.maven.resolver/maven-resolver-util
+                                                 org.apache.maven.resolver/maven-resolver-connector-basic
+                                                 org.apache.maven.resolver/maven-resolver-transport-file
+                                                 org.apache.maven.resolver/maven-resolver-transport-http
+                                                 org.apache.maven.resolver/maven-resolver-named-locks
+                                                 org.apache.httpcomponents/httpclient
+                                                 org.apache.httpcomponents/httpcore]]]
                     :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}
                     :jvm-opts ["-Dorchard.use-dynapath=false"]
                     :resource-paths ["test-resources"

--- a/src/refactor_nrepl/artifacts.clj
+++ b/src/refactor_nrepl/artifacts.clj
@@ -6,7 +6,7 @@
    [clojure.string :as str]
    [version-clj.core :as versions])
   (:import
-   (java.net HttpURLConnection URL)
+   (java.net HttpURLConnection URI)
    (java.util.zip GZIPInputStream)))
 
 (def artifacts-file (str (io/file (System/getProperty "java.io.tmpdir")
@@ -33,7 +33,7 @@
   Honors the standard `https.proxy{Host,Port}`/`http.proxy{Host,Port}` JVM properties."
   [^String url]
   (try
-    (let [conn ^HttpURLConnection (.openConnection (URL. url))]
+    (let [conn ^HttpURLConnection (.openConnection (.toURL (URI. url)))]
       (.setConnectTimeout conn 10000)
       (.setReadTimeout conn 30000)
       (try
@@ -162,6 +162,27 @@
        reverse
        list*))
 
+(defn- parse-coordinates
+  "Parse a Leiningen-style dep vector string (e.g. `\"[some/lib \\\"1.0.0\\\"]\"`)
+  or a deps.edn-style map literal into a deps.edn-style map."
+  [^String s]
+  (let [v (edn/read-string s)]
+    (cond
+      (map? v) v
+
+      (and (vector? v) (symbol? (first v)) (string? (second v)))
+      {(first v) {:mvn/version (second v)}}
+
+      :else
+      (throw (IllegalArgumentException.
+              (str "Unrecognized coordinate format: " s))))))
+
 (defn hotload-dependency
-  []
-  (throw (IllegalArgumentException. "Temporarily disabled until a solution for java 10 is found.")))
+  "Add a Maven dependency to the running classpath.
+
+  `:coordinates` is a Leiningen-style vector string `\"[group/artifact \\\"version\\\"]\"`
+  or a deps.edn-style map literal string. Returns the input string on success."
+  [{:keys [coordinates]}]
+  ((requiring-resolve 'refactor-nrepl.hotload/add-libs!)
+   (parse-coordinates coordinates))
+  coordinates)

--- a/src/refactor_nrepl/hotload.clj
+++ b/src/refactor_nrepl/hotload.clj
@@ -1,0 +1,54 @@
+(ns refactor-nrepl.hotload
+  "Runtime addition of Maven dependencies via `clojure.tools.deps`.
+
+  Designed to work both under Leiningen and the Clojure CLI: we resolve
+  coordinates through `tools.deps` directly rather than via the basis
+  machinery (which is only populated by the CLI launcher)."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.tools.deps :as deps]
+   [clojure.tools.deps.util.maven :as maven])
+  (:import
+   (clojure.lang DynamicClassLoader RT)))
+
+;; Libs already added in this JVM, keyed by symbol. Mirrors what
+;; `clojure.tools.deps/resolve-added-libs` expects as `:existing` so repeat
+;; loads no-op.
+(defonce ^:private added-libs (atom {}))
+
+(defn- find-dynamic-classloader
+  "Returns the topmost `DynamicClassLoader` in the ancestor chain of the
+  classloader that `require`/`load` currently uses (i.e. `RT.baseLoader()`),
+  or nil if none is present. Added URLs will be visible to subsequent
+  `require`/`load` calls on this thread."
+  ^DynamicClassLoader []
+  (loop [cl (RT/baseLoader)
+         found nil]
+    (cond
+      (nil? cl) found
+      (instance? DynamicClassLoader cl) (recur (.getParent cl) cl)
+      :else (recur (.getParent cl) found))))
+
+(defn add-libs!
+  "Resolves `lib-coords` (a deps.edn-style map of `lib -> coord`) and adds
+  the resulting JARs to the current `DynamicClassLoader`.
+
+  Returns the map of freshly added libs (lib -> resolved coord, with
+  `:paths`). Libs already on the classpath are skipped.
+
+  Throws `IllegalStateException` if no `DynamicClassLoader` is reachable
+  from the current thread."
+  [lib-coords]
+  (let [cl (find-dynamic-classloader)]
+    (when-not cl
+      (throw (IllegalStateException.
+              "Hotloading requires a DynamicClassLoader in the thread context; none found.")))
+    (let [{:keys [added]} (deps/resolve-added-libs
+                           {:existing @added-libs
+                            :add lib-coords
+                            :procurer {:mvn/repos maven/standard-repos}})]
+      (doseq [coord (vals added)
+              path (:paths coord)]
+        (.addURL cl (-> ^String path io/file .toURI .toURL)))
+      (swap! added-libs merge added)
+      added)))

--- a/test/refactor_nrepl/hotload_test.clj
+++ b/test/refactor_nrepl/hotload_test.clj
@@ -1,0 +1,35 @@
+(ns refactor-nrepl.hotload-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [refactor-nrepl.artifacts :as artifacts]
+   [refactor-nrepl.hotload :as hotload]))
+
+(def parse-coordinates @#'artifacts/parse-coordinates)
+
+(deftest parse-coordinates-test
+  (testing "Leiningen-style vector"
+    (is (= '{hiccup {:mvn/version "2.0.0"}}
+           (parse-coordinates "[hiccup \"2.0.0\"]"))))
+
+  (testing "qualified lib name"
+    (is (= '{org.clojure/core.async {:mvn/version "1.6.681"}}
+           (parse-coordinates "[org.clojure/core.async \"1.6.681\"]"))))
+
+  (testing "deps.edn-style map literal"
+    (is (= '{hiccup {:mvn/version "2.0.0"}}
+           (parse-coordinates "{hiccup {:mvn/version \"2.0.0\"}}"))))
+
+  (testing "invalid input"
+    (is (thrown? IllegalArgumentException
+                 (parse-coordinates "\"hiccup\"")))))
+
+(deftest add-libs!-smoke-test
+  (testing "Adds a small library end-to-end and subsequent calls are no-ops."
+    (let [added (hotload/add-libs! '{hiccup {:mvn/version "2.0.0-RC3"}})]
+      (is (contains? added 'hiccup))
+      (is (seq (:paths (get added 'hiccup))))
+      (require 'hiccup.core)
+      (is (some? (resolve 'hiccup.core/html))))
+
+    (testing "re-adding is a no-op"
+      (is (empty? (hotload/add-libs! '{hiccup {:mvn/version "2.0.0-RC3"}}))))))

--- a/test/refactor_nrepl/ns/class_search_test.clj
+++ b/test/refactor_nrepl/ns/class_search_test.clj
@@ -37,7 +37,10 @@
               ;; Stuff brought in by the `leiningen-core` dependency:
               "com/google/inject"
               "org/osgi"
-              "org/codehaus/plexus"])
+              "org/codehaus/plexus"
+              ;; Stuff brought in by the `tools.deps` dependency:
+              "junit/framework"
+              "org/eclipse/jetty"])
        (do
          (.printStackTrace e)
          false))


### PR DESCRIPTION
Hotloading was disabled years ago when alembic stopped working on Java 9. `tools.deps` provides a modern, well-maintained path: we use its `resolve-added-libs` to fetch the transitive set of JARs for a coord and add them to the `DynamicClassLoader` in `RT.baseLoader()`'s ancestor chain.

`tools.deps` ships as a regular (non-inlined) dep to avoid bloating the jar with the full Maven Resolver stack, and is loaded lazily via `requiring-resolve` only when `hotload-dependency` is actually invoked. The op accepts both the Leiningen vector format (unchanged from the old behavior) and deps.edn-style map literals.

Also tosses `.eastwood` (a local timestamp file the linter creates) into `.gitignore` while I was there, matching the convention in orchard.