### PR TITLE
Modernize CircleCI executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,10 @@ commands:
         default: "2"
     steps:
       - run:
+          name: Install packages
+          command: |
+            apt-get update && apt-get install -y nodejs unzip
+      - run:
           name: Generate Cache Checksum
           command: |
             for file in << parameters.files >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,55 +10,34 @@ version: 2.1
 
 defaults: &defaults
   working_directory: ~/repo
+  environment:
+    LEIN_ROOT: "true"   # we intend to run lein as root
+    # Parallelism is disabled due to https://github.com/benedekfazekas/mranderson/issues/56
+    LEIN_JVM_OPTS: -Dmranderson.internal.no-parallelism=true
+    # - limit the maximum heap size to prevent out of memory errors
+    # - print stacktraces to console
+    JVM_OPTS: >
+      -Xmx3200m
+      -Dclojure.main.report=stderr
 
-# Runners for OpenJDK 8/11/16/17
-
+# Runners for each supported JDK. Images come from the official
+# `clojure` Docker Hub org (https://hub.docker.com/_/clojure).
 executors:
-  openjdk8:
+  jdk8:
     docker:
-      - image: circleci/clojure:openjdk-8-lein-2.9.1-node
-    environment:
-      LEIN_ROOT: "true"   # we intended to run lein as root
-      LEIN_JVM_OPTS: -Dmranderson.internal.no-parallelism=true
-      JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
+      - image: clojure:temurin-8-lein-2.12.0-noble
     <<: *defaults
-
-  # JDK 8 is preferred for deployments (https://github.com/benedekfazekas/mranderson/issues/57)
-  # Parallelism is disabled, at least for now (https://github.com/benedekfazekas/mranderson/issues/56)
-  openjdk8_deploy:
+  jdk11:
     docker:
-      - image: circleci/clojure:openjdk-8-lein-2.9.1-node
-    environment:
-      LEIN_ROOT: "true"   # we intended to run lein as root
-      LEIN_JVM_OPTS: -Dmranderson.internal.no-parallelism=true
-      JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
+      - image: clojure:temurin-11-lein-2.12.0-noble
     <<: *defaults
-
-  openjdk11:
+  jdk17:
     docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.3-buster-node
-    environment:
-      LEIN_ROOT: "true"   # we intended to run lein as root
-      LEIN_JVM_OPTS: -Dmranderson.internal.no-parallelism=true
-      JVM_OPTS: -Xmx3200m --illegal-access=deny # forbid reflective access (this flag doesn't exist for JDK8 or JDK17+)
+      - image: clojure:temurin-17-lein-2.12.0-noble
     <<: *defaults
-
-  openjdk16:
+  jdk21:
     docker:
-      - image: circleci/clojure:openjdk-16-lein-2.9.5-buster-node
-    environment:
-      LEIN_ROOT: "true"   # we intended to run lein as root
-      LEIN_JVM_OPTS: -Dmranderson.internal.no-parallelism=true
-      JVM_OPTS: -Xmx3200m --illegal-access=deny # forbid reflective access (this flag doesn't exist for JDK8 or JDK17+)
-    <<: *defaults
-
-  openjdk17:
-    docker:
-      - image: circleci/clojure:openjdk-17-lein-2.9.5-buster-node
-    environment:
-      LEIN_ROOT: "true"   # we intended to run lein as root
-      LEIN_JVM_OPTS: -Dmranderson.internal.no-parallelism=true
-      JVM_OPTS: -Xmx3200m
+      - image: clojure:temurin-21-lein-2.12.0-noble
     <<: *defaults
 
 # Runs a given set of steps, with some standard pre- and post-
@@ -90,10 +69,6 @@ commands:
         default: "2"
     steps:
       - run:
-          name: Install make
-          command: |
-            sudo apt-get install make
-      - run:
           name: Generate Cache Checksum
           command: |
             for file in << parameters.files >>
@@ -121,7 +96,7 @@ jobs:
     parameters:
       steps:
         type: steps
-    executor: openjdk17
+    executor: jdk21
     environment:
       VERSION: "1.11"
     steps:
@@ -131,7 +106,8 @@ jobs:
           steps: << parameters.steps >>
 
   deploy:
-    executor: openjdk8_deploy
+    # JDK 8 is preferred for deployments (https://github.com/benedekfazekas/mranderson/issues/57)
+    executor: jdk8
     steps:
       - checkout
       - restore_cache:
@@ -218,7 +194,7 @@ workflows:
           matrix:
             parameters:
               clojure_version: ["1.10", "1.11", "1.12"]
-              jdk_version: [openjdk8, openjdk11, openjdk16, openjdk17]
+              jdk_version: [jdk8, jdk11, jdk17, jdk21]
           filters:
             branches:
               only: /.*/
@@ -228,7 +204,7 @@ workflows:
           matrix:
             parameters:
               clojure_version: ["1.10", "1.11", "1.12"]
-              jdk_version: [openjdk8, openjdk11, openjdk16, openjdk17]
+              jdk_version: [jdk8, jdk11, jdk17, jdk21]
           filters:
             branches:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ commands:
             for file in << parameters.files >>
             do
               find . -name $file -exec cat {} +
-            done | shasum | awk '{print $1}' > /tmp/clojure_cache_seed
+            done | sha256sum | awk '{print $1}' > /tmp/clojure_cache_seed
       - restore_cache:
           key: clojure-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
       - steps: << parameters.steps >>


### PR DESCRIPTION
The `circleci/clojure` Docker images we were on were last updated in June 2020 and sit in the deprecated `circleci/*` namespace. Switching to the maintained `clojure:temurin-*-lein-2.12.0-noble` images (same as `cider-nrepl` and `orchard`). That also bumps Leiningen from 2.9.x to 2.12.0.

While here: drop JDK 16 (interim, EOL since 2021), add JDK 21 (current LTS), collapse the duplicated `openjdk8`/`openjdk8_deploy` executors, move shared env into `defaults`, drop `--illegal-access=deny` (only valid on JDK 9-16), and stop `apt-get`-installing `make` (it's in the new image).

Side benefit: the flaky JDK 8 OOM during `.inline-deps` should settle down with modern Temurin's better container-aware memory handling.