### PR TITLE
Add make lint and shared test-session helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: inline-deps test deploy clean
+.PHONY: inline-deps test deploy clean lint
 
 VERSION ?= 1.11
 
@@ -32,6 +32,7 @@ eastwood:
 kondo:
 	lein with-profile -user,-dev,+$(VERSION),+clj-kondo run -m clj-kondo.main --lint src test
 
+lint: kondo cljfmt eastwood
 
 # Deployment is performed via CI by creating a git tag prefixed with "v".
 # Please do not deploy locally as it skips various measures (particularly around mranderson).

--- a/test/refactor_nrepl/ns/resolve_missing_caching_test.clj
+++ b/test/refactor_nrepl/ns/resolve_missing_caching_test.clj
@@ -4,13 +4,12 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [nrepl.core :as nrepl]
-   [refactor-nrepl.ns.resolve-missing-test :refer [session-fixture]]))
+   [refactor-nrepl.test-session :as session]))
 
-(use-fixtures :each session-fixture)
+(use-fixtures :each session/session-fixture)
 
 (defn message [arg-map]
-  (let [{:keys [^String error] :as response}
-        (refactor-nrepl.ns.resolve-missing-test/message arg-map)]
+  (let [{:keys [^String error] :as response} (session/message arg-map)]
     (when error
       (throw (RuntimeException. error)))
     response))

--- a/test/refactor_nrepl/ns/resolve_missing_test.clj
+++ b/test/refactor_nrepl/ns/resolve_missing_test.clj
@@ -6,44 +6,24 @@
    [clojure.test :refer [deftest is compose-fixtures testing use-fixtures]]
    [nrepl.core :as nrepl]
    [nrepl.server :as server]
-   [refactor-nrepl.middleware :as middleware]))
-
-(def ^:dynamic *handler* (server/default-handler #'middleware/wrap-refactor))
-(def ^:dynamic *session* nil)
-
-(defn session-fixture
-  [f]
-  (with-open [^nrepl.server.Server
-              server (server/start-server :bind "localhost" :handler *handler*)
-              ^nrepl.transport.FnTransport
-              transport (nrepl/connect :port (:port server))]
-    (let [client (nrepl/client transport Long/MAX_VALUE)]
-      (binding [*session* (nrepl/client-session client)]
-        (f)))))
-
-(defn message
-  ([msg] (message msg true))
-  ([msg combine-responses?]
-   (let [responses (nrepl/message *session* msg)]
-     (if combine-responses?
-       (nrepl/combine-responses responses)
-       responses))))
+   [refactor-nrepl.middleware :as middleware]
+   [refactor-nrepl.test-session :as session]))
 
 (def piggieback-fixture
   (compose-fixtures
-   session-fixture
+   session/session-fixture
    (fn [f]
-     (binding [*handler* (server/default-handler
-                          #'refactor-nrepl.middleware/wrap-refactor
-                          #'piggieback/wrap-cljs-repl)]
-       (message {:op :eval
-                 :code (nrepl/code
-                        (require '[cider.piggieback :as piggieback])
-                        (require '[cljs.repl.node :as node])
-                        (piggieback/cljs-repl (node/repl-env)))})
+     (binding [session/*handler* (server/default-handler
+                                  #'middleware/wrap-refactor
+                                  #'piggieback/wrap-cljs-repl)]
+       (session/message {:op :eval
+                         :code (nrepl/code
+                                (require '[cider.piggieback :as piggieback])
+                                (require '[cljs.repl.node :as node])
+                                (piggieback/cljs-repl (node/repl-env)))})
        (f)
-       (message {:op :eval
-                 :code (nrepl/code :cljs/quit)})))))
+       (session/message {:op :eval
+                         :code (nrepl/code :cljs/quit)})))))
 
 (use-fixtures :each piggieback-fixture)
 
@@ -54,23 +34,23 @@
             (pr-str v)))
 
   (testing "cljs repl is active"
-    (let [response (message {:op :eval
-                             :code (nrepl/code js/console)})]
+    (let [response (session/message {:op :eval
+                                     :code (nrepl/code js/console)})]
       (testing (pr-str response)
         (is (= "cljs.user" (:ns response)))
         (is (= #{"done"} (:status response))))))
 
   (testing "eval works"
-    (let [response (message {:op :eval
-                             :code (nrepl/code (map even? (range 6)))})]
+    (let [response (session/message {:op :eval
+                                     :code (nrepl/code (map even? (range 6)))})]
       (testing (pr-str response)
         (is (= "cljs.user" (:ns response)))
         (is (= ["(true false true false true false)"] (:value response)))
         (is (= #{"done"} (:status response))))))
 
   (testing "errors handled properly"
-    (let [response (message {:op :eval
-                             :code (nrepl/code (ffirst 1))})]
+    (let [response (session/message {:op :eval
+                                     :code (nrepl/code (ffirst 1))})]
       (testing (pr-str response)
         (is (= "class clojure.lang.ExceptionInfo"
                (:ex response)
@@ -80,7 +60,7 @@
 
 (deftest resolve-missing-test
   (testing "Finds functions is regular namespaces"
-    (let [{:keys [^String error] :as response} (message {:op :resolve-missing :symbol 'print-doc})
+    (let [{:keys [^String error] :as response} (session/message {:op :resolve-missing :symbol 'print-doc})
           _ (assert (string? (:candidates response))
                     (pr-str response))
           {:keys [name type]} (first (edn/read-string (:candidates response)))]
@@ -91,7 +71,7 @@
         (is (= 'cljs.repl name))
         (is (= :ns type))))
     (testing "Finds macros"
-      (let [{:keys [^String error] :as response} (message {:op :resolve-missing :symbol 'dir})
+      (let [{:keys [^String error] :as response} (session/message {:op :resolve-missing :symbol 'dir})
             {:keys [name type]} (first (edn/read-string (:candidates response)))]
         (when error
           (throw (RuntimeException. error)))

--- a/test/refactor_nrepl/test_session.clj
+++ b/test/refactor_nrepl/test_session.clj
@@ -1,0 +1,34 @@
+(ns refactor-nrepl.test-session
+  "Shared nREPL client session helpers for integration-style tests.
+
+  Modeled on `cider.nrepl.test-session`. Tests that need an in-process nREPL
+  server with refactor-nrepl's middleware installed can just do:
+
+      (use-fixtures :each refactor-nrepl.test-session/session-fixture)
+
+  and then call `(message {:op \"...\" ...})` to round-trip requests."
+  (:require
+   [nrepl.core :as nrepl]
+   [nrepl.server :as server]
+   [refactor-nrepl.middleware :as middleware]))
+
+(def ^:dynamic *handler* (server/default-handler #'middleware/wrap-refactor))
+(def ^:dynamic *session* nil)
+
+(defn session-fixture
+  [f]
+  (with-open [^nrepl.server.Server
+              server (server/start-server :bind "localhost" :handler *handler*)
+              ^nrepl.transport.FnTransport
+              transport (nrepl/connect :port (:port server))]
+    (let [client (nrepl/client transport Long/MAX_VALUE)]
+      (binding [*session* (nrepl/client-session client)]
+        (f)))))
+
+(defn message
+  ([msg] (message msg true))
+  ([msg combine-responses?]
+   (let [responses (nrepl/message *session* msg)]
+     (if combine-responses?
+       (nrepl/combine-responses responses)
+       responses))))


### PR DESCRIPTION
Borrowing two small conveniences from cider-nrepl:

- `make lint` chains `kondo`, `cljfmt`, and `eastwood` in one go — saves running them individually before pushing.
- `refactor-nrepl.test-session` centralizes the in-process nREPL server + session setup that was duplicated across integration-style tests. `resolve-missing-test` and `resolve-missing-caching-test` now share it.

(Dropped a planned CHANGELOG reformat from the original quick-wins list — turns out cider-nrepl's CHANGELOG is just as flat as ours, so there's nothing to copy there.)