### PR TITLE
Introduce def-op macro and simplify error handling

### DIFF
--- a/src/refactor_nrepl/middleware.clj
+++ b/src/refactor_nrepl/middleware.clj
@@ -33,42 +33,36 @@
     (require (symbol (namespace sym))))
   (resolve sym))
 
-(defn err-info
+(defn- err-info
   [ex status]
   {:ex (str (class ex))
    :err (with-out-str (print-cause-trace ex))
    :status #{status :done}})
 
-;; TODO - simplify this. I don't fully get why there are disparate keys depending on the exception class.
-;; Ideally, users would always get a stacktrace (however noisy).
+(defn- reply-error
+  "Build the error fragment of an nREPL response for `ex`.
+  `ExceptionInfo`, `IllegalArgumentException`, and `IllegalStateException`
+  are treated as user-facing errors (message only); anything else ships
+  with a full stacktrace."
+  [ex]
+  (when (System/getProperty "refactor-nrepl.internal.pst")
+    (.printStackTrace ^Throwable ex))
+  (cond
+    (instance? clojure.lang.ExceptionInfo ex)
+    {:error (.toString ^Throwable ex) :status #{:done}}
+
+    (or (instance? IllegalArgumentException ex)
+        (instance? IllegalStateException ex))
+    {:error (.getMessage ^Throwable ex) :status #{:done}}
+
+    :else
+    (err-info ex :refactor-nrepl-error)))
+
 (defmacro ^:private with-errors-being-passed-on [transport msg & body]
   `(try
      ~@body
-     (catch clojure.lang.ExceptionInfo e#
-       (when (System/getProperty "refactor-nrepl.internal.pst")
-         (-> e# .printStackTrace))
-       (transport/send
-        ~transport (response-for ~msg :error (.toString e#) :status :done)))
-     (catch IllegalArgumentException e#
-       (when (System/getProperty "refactor-nrepl.internal.pst")
-         (-> e# .printStackTrace))
-       (transport/send
-        ~transport (response-for ~msg :error (.getMessage e#) :status :done)))
-     (catch IllegalStateException e#
-       (when (System/getProperty "refactor-nrepl.internal.pst")
-         (-> e# .printStackTrace))
-       (transport/send
-        ~transport (response-for ~msg :error (.getMessage e#) :status :done)))
-     (catch Exception e#
-       (when (System/getProperty "refactor-nrepl.internal.pst")
-         (-> e# .printStackTrace))
-       (transport/send
-        ~transport (response-for ~msg (err-info e# :refactor-nrepl-error))))
-     (catch Error e#
-       (when (System/getProperty "refactor-nrepl.internal.pst")
-         (-> e# .printStackTrace))
-       (transport/send
-        ~transport (response-for ~msg (err-info e# :refactor-nrepl-error))))))
+     (catch Throwable e#
+       (transport/send ~transport (response-for ~msg (reply-error e#))))))
 
 (defmacro ^:private reply [transport msg & kvs]
   `(libspec-allowlist/with-memoized-libspec-allowlist
@@ -103,16 +97,63 @@
       (pr-str response) ; edn as default
       )))
 
-(def ^:private resolve-missing
-  (delay
-    (require-and-resolve 'refactor-nrepl.ns.resolve-missing/resolve-missing)))
+;;; Op registration
+;;
+;; Ops are registered in `refactor-nrepl-ops` via `def-op` (or by direct
+;; assoc for ops with non-standard reply logic). `def-op` is shorthand
+;; for the common case: a handler that takes the incoming msg and whose
+;; return value gets echoed back under a single response key.
 
-(defn resolve-missing-reply [{:keys [transport] :as msg}]
-  (reply transport msg :candidates (@resolve-missing msg) :status :done))
+(defonce refactor-nrepl-ops (atom {}))
+
+(defn- register-op! [op-name reply-fn]
+  (swap! refactor-nrepl-ops assoc op-name reply-fn))
+
+(defmacro def-op
+  "Register a simple nREPL op.
+
+  `op-name`      - op name (string).
+  `handler-sym`  - quoted fully-qualified symbol of the handler fn;
+                   required and resolved lazily on first use.
+  `result-key`   - keyword under which to send the handler's return value.
+
+  Options:
+    :serialize? - pass the handler result through `serialize-response`
+                  before replying (honors :serialization-format in msg)
+    :pr-str     - pr-str the handler result before replying
+    :no-args?   - invoke the handler with no arguments (default: pass msg)"
+  [op-name handler-sym result-key & {:keys [serialize? pr-str no-args?]}]
+  (let [handler (gensym "handler-")
+        msg (gensym "msg-")
+        result (if no-args?
+                 `(@~handler)
+                 `(@~handler ~msg))
+        value (cond
+                serialize? `(serialize-response ~msg ~result)
+                pr-str     `(pr-str ~result)
+                :else      result)]
+    `(let [~handler (delay (require-and-resolve ~handler-sym))]
+       (register-op! ~op-name
+                     (fn [{:keys [~'transport] :as ~msg}]
+                       (reply ~'transport ~msg ~result-key ~value :status :done))))))
+
+;;; Ops with standard reply logic
+
+(def-op "resolve-missing"      'refactor-nrepl.ns.resolve-missing/resolve-missing :candidates)
+(def-op "artifact-list"        'refactor-nrepl.artifacts/artifact-list            :artifacts)
+(def-op "artifact-versions"    'refactor-nrepl.artifacts/artifact-versions        :versions)
+(def-op "hotload-dependency"   'refactor-nrepl.artifacts/hotload-dependency       :dependency)
+(def-op "find-used-locals"     'refactor-nrepl.find.find-locals/find-used-locals  :used-locals)
+(def-op "warm-ast-cache"       'refactor-nrepl.analyzer/warm-ast-cache            :ast-statuses :serialize? true :no-args? true)
+(def-op "extract-definition"   'refactor-nrepl.extract-definition/extract-definition :definition :pr-str true)
+(def-op "namespace-aliases"    'refactor-nrepl.ns.libspecs/namespace-aliases-response :namespace-aliases :serialize? true)
+(def-op "cljr-suggest-libspecs" 'refactor-nrepl.ns.suggest-libspecs/suggest-libspecs-response :suggestions :serialize? true)
+(def-op "find-used-publics"    'refactor-nrepl.find.find-used-publics/find-used-publics :used-publics :serialize? true)
+
+;;; Ops with custom reply logic
 
 (def ^:private find-symbol
-  (delay
-    (require-and-resolve 'refactor-nrepl.find.find-symbol/find-symbol)))
+  (delay (require-and-resolve 'refactor-nrepl.find.find-symbol/find-symbol)))
 
 (defn- find-symbol-reply [{:keys [transport] :as msg}]
   (let [occurrences (@find-symbol msg)]
@@ -120,124 +161,50 @@
       (reply transport msg :occurrence (serialize-response msg occurrence)))
     (reply transport msg :count (count occurrences) :status :done)))
 
-(def ^:private artifact-list
-  (delay (require-and-resolve 'refactor-nrepl.artifacts/artifact-list)))
-
-(def ^:private artifact-versions
-  (delay (require-and-resolve 'refactor-nrepl.artifacts/artifact-versions)))
-
-(def ^:private hotload-dependency
-  (delay (require-and-resolve 'refactor-nrepl.artifacts/hotload-dependency)))
-
-(defn- artifact-list-reply [{:keys [transport] :as msg}]
-  (reply transport msg :artifacts (@artifact-list msg) :status :done))
-
-(defn- artifact-versions-reply [{:keys [transport] :as msg}]
-  (reply transport msg :versions (@artifact-versions msg) :status :done))
-
-(defn- hotload-dependency-reply [{:keys [transport] :as msg}]
-  (reply transport msg :status :done :dependency (@hotload-dependency msg)))
+(register-op! "find-symbol" find-symbol-reply)
 
 (def ^:private clean-ns
-  (delay
-    (require-and-resolve 'refactor-nrepl.ns.clean-ns/clean-ns)))
+  (delay (require-and-resolve 'refactor-nrepl.ns.clean-ns/clean-ns)))
 
 (def ^:private pprint-ns
-  (delay
-    (require-and-resolve 'refactor-nrepl.ns.pprint/pprint-ns)))
+  (delay (require-and-resolve 'refactor-nrepl.ns.pprint/pprint-ns)))
 
 (defn- clean-ns-reply [{:keys [transport] :as msg}]
   (reply transport msg :ns (some-> msg (@clean-ns) (@pprint-ns)) :status :done))
 
-(def ^:private find-used-locals
-  (delay
-    (require-and-resolve 'refactor-nrepl.find.find-locals/find-used-locals)))
+(register-op! "clean-ns" clean-ns-reply)
 
-(defn- find-used-locals-reply [{:keys [transport] :as msg}]
-  (reply transport msg :used-locals (@find-used-locals msg) :status :done))
+(def ^:private rename-file-or-dir
+  (delay (require-and-resolve 'refactor-nrepl.rename-file-or-dir/rename-file-or-dir)))
 
-(defn- version-reply [{:keys [transport] :as msg}]
-  (reply transport msg :status :done :version (core/version)))
+(defn- rename-file-or-dir-reply [{:keys [transport old-path new-path ignore-errors] :as msg}]
+  (reply transport msg
+         :touched (@rename-file-or-dir old-path new-path (= ignore-errors "true"))
+         :status :done))
 
-(def ^:private warm-ast-cache
-  (delay
-    (require-and-resolve 'refactor-nrepl.analyzer/warm-ast-cache)))
-
-(defn- warm-ast-cache-reply [{:keys [transport] :as msg}]
-  (reply transport msg :status :done
-         :ast-statuses (serialize-response msg (@warm-ast-cache))))
+(register-op! "rename-file-or-dir" rename-file-or-dir-reply)
 
 (defn- stubs-for-interface-reply [{:keys [transport] :as msg}]
   (reply transport msg :status :done
          :functions (serialize-response msg (stubs-for-interface msg))))
 
-(def ^:private extract-definition
-  (delay
-    (require-and-resolve 'refactor-nrepl.extract-definition/extract-definition)))
+(register-op! "stubs-for-interface" stubs-for-interface-reply)
 
-(defn- extract-definition-reply [{:keys [transport] :as msg}]
-  (reply transport msg :status :done :definition (pr-str (@extract-definition msg))))
+(defn- version-reply [{:keys [transport] :as msg}]
+  (reply transport msg :status :done :version (core/version)))
 
-(def ^:private rename-file-or-dir
-  (delay
-    (require-and-resolve 'refactor-nrepl.rename-file-or-dir/rename-file-or-dir)))
+(register-op! "version" version-reply)
 
-(defn- rename-file-or-dir-reply [{:keys [transport old-path new-path ignore-errors] :as msg}]
-  (reply transport msg :touched (@rename-file-or-dir old-path new-path (= ignore-errors "true"))
-         :status :done))
-
-(def namespace-aliases
-  (delay
-    (require-and-resolve 'refactor-nrepl.ns.libspecs/namespace-aliases-response)))
-
-(defn- namespace-aliases-reply [{:keys [transport] :as msg}]
-  (let [aliases (@namespace-aliases msg)]
-    (reply transport msg
-           :namespace-aliases (serialize-response msg aliases)
-           :status :done)))
-
-(def suggest-libspecs
-  (delay
-    (require-and-resolve 'refactor-nrepl.ns.suggest-libspecs/suggest-libspecs-response)))
-
-(defn- suggest-libspecs-reply [{:keys [transport] :as msg}]
-  (reply transport
-         msg
-         :suggestions (serialize-response msg (@suggest-libspecs msg))
-         :status :done))
-
-(def ^:private find-used-publics
-  (delay (require-and-resolve 'refactor-nrepl.find.find-used-publics/find-used-publics)))
-
-(defn- find-used-publics-reply [{:keys [transport] :as msg}]
-  (reply transport msg
-         :used-publics (serialize-response msg (@find-used-publics msg)) :status :done))
-
-(def refactor-nrepl-ops
-  {"artifact-list"                artifact-list-reply
-   "artifact-versions"            artifact-versions-reply
-   "clean-ns"                     clean-ns-reply
-   "cljr-suggest-libspecs"        suggest-libspecs-reply
-   "extract-definition"           extract-definition-reply
-   "find-symbol"                  find-symbol-reply
-   "find-used-locals"             find-used-locals-reply
-   "hotload-dependency"           hotload-dependency-reply
-   "namespace-aliases"            namespace-aliases-reply
-   "rename-file-or-dir"           rename-file-or-dir-reply
-   "resolve-missing"              resolve-missing-reply
-   "stubs-for-interface"          stubs-for-interface-reply
-   "find-used-publics"            find-used-publics-reply
-   "version"                      version-reply
-   "warm-ast-cache"               warm-ast-cache-reply})
+;;; Middleware
 
 (defn wrap-refactor
   [handler]
   (fn [{:keys [op] :as msg}]
-    ((get refactor-nrepl-ops op handler) msg)))
+    ((get @refactor-nrepl-ops op handler) msg)))
 
 (set-descriptor!
  #'wrap-refactor
  (cljs/requires-piggieback
-  {:handles (zipmap (keys refactor-nrepl-ops)
+  {:handles (zipmap (keys @refactor-nrepl-ops)
                     (repeat {:doc "See the refactor-nrepl README"
                              :returns {} :requires {}}))}))


### PR DESCRIPTION
Borrowing the spirit of cider-nrepl's `def-wrapper` pattern.

Adding a new nREPL op used to require three separate edits in `middleware.clj` - a `delay`, a `-reply` fn, and an entry in the `refactor-nrepl-ops` map. A single `def-op` form now covers the common case (handler result echoed back under one response key), with `:serialize?`, `:pr-str`, and `:no-args?` switches for the variants. Ten ops moved to the new form; five with custom reply logic (find-symbol streaming, rename-file-or-dir's extra args, clean-ns composing two handlers, stubs-for-interface, version) stay explicit but use the same `register-op!` hook.

While here, `with-errors-being-passed-on`'s five near-identical catch branches collapsed into a single Throwable catch + `reply-error` helper. Same user-visible behavior (ExceptionInfo/IllegalArgumentException/IllegalStateException → message-only reply, everything else → full stacktrace), much less noise.

Verified via an end-to-end nREPL roundtrip that the version op, the error path for an unknown-coordinate `hotload-dependency`, and the error path for a missing `resolve-missing` symbol all behave as before.