### PR TITLE
[Fix #408] Don't wrap cljs auto-aliased namespaces in :clj reader conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#415](https://github.com/clojure-emacs/refactor-nrepl/issues/415): Remove Compliment dependency.
 * [#231](https://github.com/clojure-emacs/refactor-nrepl/issues/231): Restore `hotload-dependency` on top of `clojure.tools.deps`. Also accepts `deps.edn`-style map literals in addition to Leiningen vectors.
+* [#408](https://github.com/clojure-emacs/refactor-nrepl/issues/408): `suggest-libspecs` no longer wraps `clojure.math` (and other ClojureScript auto-aliased namespaces like `clojure.pprint`, `clojure.repl`) in a `:clj` reader conditional inside `.cljc` files.
 
 ## 3.11.0 (2025-05-04)
 

--- a/src/refactor_nrepl/ns/suggest_libspecs.clj
+++ b/src/refactor_nrepl/ns/suggest_libspecs.clj
@@ -74,16 +74,32 @@
               (distinct))
         filenames))
 
+;; ClojureScript auto-aliases requires of these `clojure.*` namespaces to their
+;; `cljs.*` counterparts (see `cljs.analyzer/aliasable-clj-ns?`). That makes a
+;; plain `[clojure.X :as ...]` valid in both Clojure and ClojureScript, so we
+;; should treat them as `:cljc` even though only the JVM file is on the classpath.
+(def cljs-auto-aliased-paths
+  #{"clojure/test.clj"
+    "clojure/pprint.clj"
+    "clojure/math.clj"
+    "clojure/repl.clj"
+    "clojure/template.clj"
+    "clojure/spec/alpha.clj"
+    "clojure/spec/gen/alpha.clj"
+    "clojure/spec/test/alpha.clj"})
+
 (defn files->platform [filenames]
   (let [extensions (filenames->extensions filenames)
         cljc? (some #{".cljc"} extensions)
         clj? (some #{".clj"} extensions)
         cljs? (some #{".cljs"} extensions)
-        jvm-clojure-test? (some (fn [s]
-                                  (string/ends-with? s "clojure/test.clj"))
-                                filenames)]
+        cljs-auto-aliased? (some (fn [s]
+                                   (some (fn [suffix]
+                                           (string/ends-with? s suffix))
+                                         cljs-auto-aliased-paths))
+                                 filenames)]
     (cond
-      jvm-clojure-test? ;; 'clojure.test can always be used in any platform
+      cljs-auto-aliased? ;; usable from both platforms thanks to cljs auto-aliasing
       :cljc
 
       (and cljc?

--- a/test/refactor_nrepl/ns/suggest_libspecs_test.clj
+++ b/test/refactor_nrepl/ns/suggest_libspecs_test.clj
@@ -66,6 +66,14 @@
     "test"       "cljc"      "cljs"     []                                   {}                              ["[clojure.test :as test]"]
     "test"       "cljc"      "cljc"     []                                   {}                              ["[clojure.test :as test]"]
 
+    ;; clojure.math is auto-aliased to cljs.math by the ClojureScript compiler, so it should not be
+    ;; wrapped in a :clj reader conditional in .cljc files - https://github.com/clojure-emacs/refactor-nrepl/issues/408
+    "math"       "clj"       "clj"      [["math" "clojure.math"]]            {}                              ["[clojure.math :as math]"]
+    "math"       "cljs"      "cljs"     [["math" "clojure.math"]]            {}                              ["[clojure.math :as math]"]
+    "math"       "cljc"      "clj"      [["math" "clojure.math"]]            {}                              ["[clojure.math :as math]"]
+    "math"       "cljc"      "cljs"     [["math" "clojure.math"]]            {}                              ["[clojure.math :as math]"]
+    "math"       "cljc"      "cljc"     [["math" "clojure.math"]]            {}                              ["[clojure.math :as math]"]
+
     ;; Example story 1:
     "set"        "cljc"      "cljc"     [["set" "clojure.set"]]              {}                              ["[clojure.set :as set]"]
     ;; Story 2 - preferred-aliases are disregarded if the libspecs found in the project differ:


### PR DESCRIPTION
Fixes #408.

`suggest-libspecs` was wrapping `clojure.math` in `#?(:clj ...)` inside `.cljc` files, even though ClojureScript auto-aliases `clojure.math` to `cljs.math` (and same for `clojure.pprint`, `clojure.repl`, etc.). The existing special case in `files->platform` only knew about `clojure.test`; I extended it via a small allowlist of paths that mirror cljs's `aliasable-clj-ns?` rule.

- [x] The commits are consistent with our [contribution guidelines](./CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [ ] Code inlining with mranderson works and tests pass with inlined code (run `make install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)