### PR TITLE
[Fix #405] Warm class-search cache in the background on namespace load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#415](https://github.com/clojure-emacs/refactor-nrepl/issues/415): Remove Compliment dependency.
 * [#231](https://github.com/clojure-emacs/refactor-nrepl/issues/231): Restore `hotload-dependency` on top of `clojure.tools.deps`. Also accepts `deps.edn`-style map literals in addition to Leiningen vectors.
 * [#408](https://github.com/clojure-emacs/refactor-nrepl/issues/408): `suggest-libspecs` no longer wraps `clojure.math` (and other ClojureScript auto-aliased namespaces like `clojure.pprint`, `clojure.repl`) in a `:clj` reader conditional inside `.cljc` files.
+* [#405](https://github.com/clojure-emacs/refactor-nrepl/issues/405): Warm the `available-classes` cache in the background, reducing first-request latency for `resolve-missing`.
 
 ## 3.11.0 (2025-05-04)
 

--- a/src/refactor_nrepl/ns/class_search.clj
+++ b/src/refactor_nrepl/ns/class_search.clj
@@ -129,3 +129,11 @@
 
 (defn available-classes-by-last-segment []
   (recompute-if-classpath-changed #(get-available-classes-by-last-segment)))
+
+;; Eagerly populate the cache in the background as soon as this namespace loads,
+;; so that the first user-triggered call (typically through `resolve-missing`)
+;; doesn't pay the full classpath-scanning cost. The cache itself is keyed on
+;; classpath hash, so re-running on namespace reload is harmless.
+(future
+  (try (available-classes-by-last-segment)
+       (catch Throwable _)))


### PR DESCRIPTION
Fixes #405.

The original ticket asked to flip `available-classes` from `delay` to `future` so the classpath scan happens eagerly. The `delay` was removed during the Compliment cleanup (#415), but the underlying issue stands: `resolve-missing`'s first request still pays the full scanning cost. Solved by spawning a one-shot background `future` at namespace-load time. The cache itself is keyed on classpath hash, so re-running on namespace reload is harmless.

- [x] The commits are consistent with our [contribution guidelines](./CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [ ] Code inlining with mranderson works and tests pass with inlined code (run `make install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)