### PR TITLE
[#347] Add regression test for namespaces that set! *warn-on-reflection*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#347](https://github.com/clojure-emacs/refactor-nrepl/issues/347): Add regression test covering AST building for namespaces that `set!` `*warn-on-reflection*`/`*unchecked-math*`. The original failure no longer reproduces with the current `tools.analyzer.jvm`.
 * [#415](https://github.com/clojure-emacs/refactor-nrepl/issues/415): Remove Compliment dependency.
 * [#231](https://github.com/clojure-emacs/refactor-nrepl/issues/231): Restore `hotload-dependency` on top of `clojure.tools.deps`. Also accepts `deps.edn`-style map literals in addition to Leiningen vectors.
 * [#408](https://github.com/clojure-emacs/refactor-nrepl/issues/408): `suggest-libspecs` no longer wraps `clojure.math` (and other ClojureScript auto-aliased namespaces like `clojure.pprint`, `clojure.repl`) in a `:clj` reader conditional inside `.cljc` files.

--- a/test-resources/uses_warn_on_reflection.clj
+++ b/test-resources/uses_warn_on_reflection.clj
@@ -1,0 +1,7 @@
+(ns uses-warn-on-reflection)
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn echo [x]
+  x)

--- a/test-resources/uses_warn_on_reflection_cljc.cljc
+++ b/test-resources/uses_warn_on_reflection_cljc.cljc
@@ -1,0 +1,6 @@
+(ns uses-warn-on-reflection-cljc)
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn echo [x]
+  x)

--- a/test/refactor_nrepl/analyzer_test.clj
+++ b/test/refactor_nrepl/analyzer_test.clj
@@ -7,7 +7,10 @@
 
 (deftest ns-ast-test
   (doseq [f ["core_async_usage.clj"
-             "clashing_defprotocol_method_name.clj"]
+             "clashing_defprotocol_method_name.clj"
+             ;; https://github.com/clojure-emacs/refactor-nrepl/issues/347
+             "uses_warn_on_reflection.clj"
+             "uses_warn_on_reflection_cljc.cljc"]
           :let [c (-> f io/resource slurp)]]
     (is (some? (sut/ns-ast c)))))
 


### PR DESCRIPTION
The original report (refactor-nrepl 2.5.1, 2021) was that building an AST for a namespace with `(set! *warn-on-reflection* true)` at the top level threw `Can't set!: *warn-on-reflection* from non-binding thread`. I couldn't reproduce it against the current `tools.analyzer.jvm` (1.3.4) - both `.clj` and `.cljc` cases build cleanly.

Adding two fixtures to `ns-ast-test` so we catch any future analyzer/tooling update that re-breaks this. No production code change.

Once this lands I'd close #347 as resolved-upstream.

- [x] The commits are consistent with our [contribution guidelines](./CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [ ] Code inlining with mranderson works and tests pass with inlined code (run `make install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)