### PR TITLE
[Fix #380] Mark internal helper namespaces with ^:no-doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#380](https://github.com/clojure-emacs/refactor-nrepl/issues/380): Mark internal helper namespaces with `^:no-doc` so cljdoc surfaces only the public API (the namespaces backing nREPL ops plus a few user-facing helpers like `ns.libspec-allowlist` and `ns.pprint`).
 * [#347](https://github.com/clojure-emacs/refactor-nrepl/issues/347): Add regression test covering AST building for namespaces that `set!` `*warn-on-reflection*`/`*unchecked-math*`. The original failure no longer reproduces with the current `tools.analyzer.jvm`.
 * [#415](https://github.com/clojure-emacs/refactor-nrepl/issues/415): Remove Compliment dependency.
 * [#231](https://github.com/clojure-emacs/refactor-nrepl/issues/231): Restore `hotload-dependency` on top of `clojure.tools.deps`. Also accepts `deps.edn`-style map literals in addition to Leiningen vectors.

--- a/src/refactor_nrepl/core.clj
+++ b/src/refactor_nrepl/core.clj
@@ -1,4 +1,4 @@
-(ns refactor-nrepl.core
+(ns ^:no-doc refactor-nrepl.core
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/src/refactor_nrepl/find/bindings.clj
+++ b/src/refactor_nrepl/find/bindings.clj
@@ -1,7 +1,7 @@
 ;; Taken from https://github.com/alexander-yakushev/compliment 0.2.4
 ;; Copyright © 2013-2014 Alexander Yakushev. Distributed under the
 ;; Eclipse Public License, the same as Clojure.
-(ns refactor-nrepl.find.bindings)
+(ns ^:no-doc refactor-nrepl.find.bindings)
 
 (def ^:private let-like-forms
   "Forms that create binding vector like let does."

--- a/src/refactor_nrepl/find/symbols_in_file.clj
+++ b/src/refactor_nrepl/find/symbols_in_file.clj
@@ -1,4 +1,4 @@
-(ns refactor-nrepl.find.symbols-in-file
+(ns ^:no-doc refactor-nrepl.find.symbols-in-file
   (:require
    [clojure.java.io :as io]
    [clojure.tools.reader :as reader]

--- a/src/refactor_nrepl/find/util.clj
+++ b/src/refactor_nrepl/find/util.clj
@@ -1,4 +1,4 @@
-(ns refactor-nrepl.find.util
+(ns ^:no-doc refactor-nrepl.find.util
   (:require
    [clojure.java.io :as io]
    [refactor-nrepl.core :as core]))

--- a/src/refactor_nrepl/fs.clj
+++ b/src/refactor_nrepl/fs.clj
@@ -1,4 +1,4 @@
-(ns refactor-nrepl.fs
+(ns ^:no-doc refactor-nrepl.fs
   "Sets the compile-time feature-flags from the `fs` library.
   This ns should be `require`d before any other `fs` ns."
   (:require

--- a/src/refactor_nrepl/ns/imports_and_refers_analysis.clj
+++ b/src/refactor_nrepl/ns/imports_and_refers_analysis.clj
@@ -1,7 +1,7 @@
 ;;;; Copied from slamhound 1.5.5
 ;;;; Copyright © 2011-2012 Phil Hagelberg and contributors
 ;;;; Distributed under the Eclipse Public License, the same as Clojure.
-(ns refactor-nrepl.ns.imports-and-refers-analysis
+(ns ^:no-doc refactor-nrepl.ns.imports-and-refers-analysis
   "Formerly known as `refactor-nrepl.ns.slam.hound.regrow`."
   (:require
    [refactor-nrepl.ns.class-search :as class-search]))

--- a/src/refactor_nrepl/ns/prune_dependencies.clj
+++ b/src/refactor_nrepl/ns/prune_dependencies.clj
@@ -1,4 +1,4 @@
-(ns refactor-nrepl.ns.prune-dependencies
+(ns ^:no-doc refactor-nrepl.ns.prune-dependencies
   (:require
    [cider.nrepl.middleware.info :as info]
    [clojure.set :as set]

--- a/src/refactor_nrepl/ns/rebuild.clj
+++ b/src/refactor_nrepl/ns/rebuild.clj
@@ -1,4 +1,4 @@
-(ns refactor-nrepl.ns.rebuild
+(ns ^:no-doc refactor-nrepl.ns.rebuild
   (:require
    [clojure.string :as str]
    [refactor-nrepl.config :as config]

--- a/src/refactor_nrepl/ns/suggest_libspecs.clj
+++ b/src/refactor_nrepl/ns/suggest_libspecs.clj
@@ -1,4 +1,4 @@
-(ns refactor-nrepl.ns.suggest-libspecs
+(ns ^:no-doc refactor-nrepl.ns.suggest-libspecs
   "Beta middleware, meant only for internal development. Subject to change."
   (:refer-clojure :exclude [alias])
   (:require

--- a/src/refactor_nrepl/ns/tracker.clj
+++ b/src/refactor_nrepl/ns/tracker.clj
@@ -1,4 +1,4 @@
-(ns refactor-nrepl.ns.tracker
+(ns ^:no-doc refactor-nrepl.ns.tracker
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/src/refactor_nrepl/util.clj
+++ b/src/refactor_nrepl/util.clj
@@ -1,4 +1,4 @@
-(ns refactor-nrepl.util
+(ns ^:no-doc refactor-nrepl.util
   (:require
    [clojure.java.io :as io]
    [clojure.string :as string])

--- a/src/refactor_nrepl/util/meta.clj
+++ b/src/refactor_nrepl/util/meta.clj
@@ -1,4 +1,4 @@
-(ns refactor-nrepl.util.meta
+(ns ^:no-doc refactor-nrepl.util.meta
   "Metadata-oriented helpers."
   (:refer-clojure :exclude [distinct]))
 


### PR DESCRIPTION
Fixes #380.

Hides 13 internal helper namespaces from cljdoc via `^:no-doc` on their `ns` forms, leaving the documented surface as the namespaces backing nREPL ops plus a handful that have been called out historically (`config`, `ns.libspec-allowlist`, `ns.pprint`) and a few useful helpers (`ns-parser`, `suggest-aliases`, `class-search`, `find-macros`, `s-expressions`).

The hidden ones: `core`, `util`, `util.meta`, `fs`, `find.bindings`, `find.util`, `find.symbols-in-file`, `ns.imports-and-refers-analysis`, `ns.prune-dependencies`, `ns.rebuild`, `ns.tracker`, `ns.suggest-libspecs` (already self-described as beta).

Once this lands, @lread the public surface is what's left after this filter — happy to chat further if any of the borderline calls feel wrong.

- [x] The commits are consistent with our [contribution guidelines](./CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [ ] Code inlining with mranderson works and tests pass with inlined code (run `make install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)