### PR TITLE
Namespace ops with refactor/ prefix (cider-nrepl convention)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Register every nREPL op under both its bare name and a `refactor/`-prefixed name (e.g. `refactor/clean-ns`, `refactor/find-symbol`). The bare names continue to work but are deprecated and will be removed in a future major release. Mirrors the convention used by `cider-nrepl`.
+
 ## 3.12.0 (2026-05-10)
 
 * [#380](https://github.com/clojure-emacs/refactor-nrepl/issues/380): Mark internal helper namespaces with `^:no-doc` so cljdoc surfaces only the public API (the namespaces backing nREPL ops plus a few user-facing helpers like `ns.libspec-allowlist` and `ns.pprint`).

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ nil
 
 In the example above we're talking to one of the built-in nREPL ops, `eval`, passing it the data `:code "(+ 2 3)"`.  The rest of the readme details our own nREPL ops which provide various refactoring support.
 
+> [!NOTE]
+> Starting with 3.13.0, every refactor-nrepl op is also available under
+> a `refactor/`-prefixed name (e.g. `refactor/clean-ns`,
+> `refactor/find-symbol`). The bare names (`clean-ns`, `find-symbol`,
+> ...) continue to work for backward compatibility but are deprecated
+> and will be removed in a future major release. Prefer the namespaced
+> form in new client code; it avoids collisions with other middleware
+> that may register ops with the same bare name (`version`, `clean-ns`,
+> etc.).
+
 ## Available features
 
 ### Configuration

--- a/src/refactor_nrepl/middleware.clj
+++ b/src/refactor_nrepl/middleware.clj
@@ -103,11 +103,19 @@
 ;; assoc for ops with non-standard reply logic). `def-op` is shorthand
 ;; for the common case: a handler that takes the incoming msg and whose
 ;; return value gets echoed back under a single response key.
+;;
+;; Each op is registered under two keys: the legacy bare name (e.g.
+;; `clean-ns`) and the namespaced form (`refactor/clean-ns`). The
+;; namespaced form is preferred; the bare names are retained for
+;; backward compatibility and will be removed in a future major release.
+;; This mirrors the convention used by cider-nrepl.
 
 (defonce refactor-nrepl-ops (atom {}))
 
+(def op-prefix "refactor/")
+
 (defn- register-op! [op-name reply-fn]
-  (swap! refactor-nrepl-ops assoc op-name reply-fn))
+  (swap! refactor-nrepl-ops assoc op-name reply-fn (str op-prefix op-name) reply-fn))
 
 (defmacro def-op
   "Register a simple nREPL op.
@@ -202,9 +210,16 @@
   (fn [{:keys [op] :as msg}]
     ((get @refactor-nrepl-ops op handler) msg)))
 
+(defn- describe-op [op-name]
+  (if (.startsWith ^String op-name op-prefix)
+    {:doc "See the refactor-nrepl README"
+     :returns {} :requires {}}
+    {:doc (str "Deprecated: use `" op-prefix op-name "` instead. See the refactor-nrepl README.")
+     :returns {} :requires {}}))
+
 (set-descriptor!
  #'wrap-refactor
  (cljs/requires-piggieback
-  {:handles (zipmap (keys @refactor-nrepl-ops)
-                    (repeat {:doc "See the refactor-nrepl README"
-                             :returns {} :requires {}}))}))
+  {:handles (into {}
+                  (map (fn [op] [op (describe-op op)]))
+                  (keys @refactor-nrepl-ops))}))

--- a/test/refactor_nrepl/middleware_test.clj
+++ b/test/refactor_nrepl/middleware_test.clj
@@ -1,0 +1,30 @@
+(ns refactor-nrepl.middleware-test
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [refactor-nrepl.middleware :as middleware]
+   [refactor-nrepl.test-session :as session]))
+
+(use-fixtures :each session/session-fixture)
+
+(deftest ops-are-registered-under-bare-and-namespaced-names
+  (let [registered (set (keys @middleware/refactor-nrepl-ops))]
+    (testing "every bare op has a refactor/<op> counterpart"
+      (doseq [op registered
+              :when (not (.startsWith ^String op middleware/op-prefix))]
+        (is (contains? registered (str middleware/op-prefix op))
+            (str op " is missing its " middleware/op-prefix " counterpart"))))
+    (testing "namespaced names route to the same handler as bare names"
+      (doseq [op registered
+              :when (not (.startsWith ^String op middleware/op-prefix))]
+        (is (identical? (get @middleware/refactor-nrepl-ops op)
+                        (get @middleware/refactor-nrepl-ops (str middleware/op-prefix op))))))))
+
+(deftest version-op-works-under-both-names
+  (testing "bare name (legacy)"
+    (let [response (session/message {:op "version"})]
+      (is (string? (:version response)))
+      (is (contains? (:status response) "done"))))
+  (testing "namespaced name"
+    (let [response (session/message {:op "refactor/version"})]
+      (is (string? (:version response)))
+      (is (contains? (:status response) "done")))))


### PR DESCRIPTION
Every op is now registered under two names: the legacy bare form (e.g. `clean-ns`) and a `refactor/`-prefixed form (`refactor/clean-ns`), pointing at the same handler. Mirrors cider-nrepl's pattern (and addresses the long-standing ambiguity around generic names like `version` colliding with other middleware).

Backward compatibility is preserved: bare names keep working. Their descriptor docstrings are now prefixed with `"Deprecated: use \`refactor/<op>\` instead."` so clients can introspect the deprecation.

Added a small `middleware_test.clj` covering both registration symmetry and a round-trip on the `version` / `refactor/version` pair.

Plan to drop the bare names in a future major release.

- [x] The commits are consistent with our [contribution guidelines](./CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (run `lein do clean, test`)
- [ ] Code inlining with mranderson works and tests pass with inlined code (run `make install` -- takes a long time)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)