### PR TITLE
Wrap referred-syms-by-file&fullname's pmap in with-suppressed-errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Register every nREPL op under both its bare name and a `refactor/`-prefixed name (e.g. `refactor/clean-ns`, `refactor/find-symbol`). The bare names continue to work but are deprecated and will be removed in a future major release. Mirrors the convention used by `cider-nrepl`.
+* Fix `referred-syms-by-file&fullname` (used by `find-symbol`) leaking parse exceptions out of its `pmap` when a source directory contained an unparseable file (e.g. an empty placeholder or `data_readers.clj`). The two other call sites already wrapped via `with-suppressed-errors`; this aligns the third.
 
 ## 3.12.0 (2026-05-10)
 

--- a/src/refactor_nrepl/ns/libspecs.clj
+++ b/src/refactor_nrepl/ns/libspecs.clj
@@ -202,15 +202,21 @@
    (referred-syms-by-file&fullname false))
   ([ignore-errors?]
    ;; `pmap` is used as it has proved to be more efficient, both for cached and non-cached cases.
+   ;; `with-suppressed-errors` makes sure files that can't be parsed (e.g. empty placeholder
+   ;; files, `data_readers.clj`) don't surface an exception out of `pmap`.
    {:clj  (->> (core/find-in-project (util/with-suppressed-errors
                                        (some-fn core/clj-file? core/cljc-file?)
                                        ignore-errors?)
                                      (core/source-dirs-on-classpath))
-               (pmap (juxt identity (partial get-libspec-from-file-with-caching :clj)))
+               (pmap (juxt identity (util/with-suppressed-errors
+                                      (partial get-libspec-from-file-with-caching :clj)
+                                      ignore-errors?)))
                sym-by-file&fullname)
     :cljs (->> (core/find-in-project (util/with-suppressed-errors
                                        (some-fn core/cljs-file? core/cljc-file?)
                                        ignore-errors?)
                                      (core/source-dirs-on-classpath))
-               (pmap (juxt identity (partial get-libspec-from-file-with-caching :cljs)))
+               (pmap (juxt identity (util/with-suppressed-errors
+                                      (partial get-libspec-from-file-with-caching :cljs)
+                                      ignore-errors?)))
                sym-by-file&fullname)}))


### PR DESCRIPTION
While investigating the intermittent CI failures (\`Ran 162 tests, 0 failures, 1 errors\` rotating across matrix cells) I noticed that of the three call sites of \`get-libspec-from-file-with-caching\`, two wrap the call in \`with-suppressed-errors\` and the third — \`referred-syms-by-file&fullname\`, used by \`find-symbol\` — doesn't.

Any one unparseable file in a project's source dirs (placeholder files, \`data_readers.clj\`, WIP code) makes \`put-cached-ns-info!\` throw \`IllegalStateException: No ns form at ...\`. In the two wrapped paths it's caught and logged; in this one it leaked straight out of \`pmap\`.

\`ignore-errors?\` is honored: when callers explicitly pass \`false\`, the wrapper returns the unwrapped fn and the exception propagates as before, so the existing \`add-tentative-aliases-test\` "ignore-errors?" assertion still passes.

I'm not 100% certain this is the root cause of the CI flake — couldn't reproduce locally on macOS even with the CI flag set + mranderson — but it's a real bug regardless and matches the symptoms (intermittent because pmap worker scheduling determines whether the bad file is hit before the result is consumed).

- [x] Existing libspecs/namespace-aliases/suggest-libspecs tests still pass
- [x] Lint clean
- [x] CHANGELOG updated