### PR TITLE
Bump nrepl to 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Register every nREPL op under both its bare name and a `refactor/`-prefixed name (e.g. `refactor/clean-ns`, `refactor/find-symbol`). The bare names continue to work but are deprecated and will be removed in a future major release. Mirrors the convention used by `cider-nrepl`.
 * Fix `referred-syms-by-file&fullname` (used by `find-symbol`) leaking parse exceptions out of its `pmap` when a source directory contained an unparseable file (e.g. an empty placeholder or `data_readers.clj`). The two other call sites already wrapped via `with-suppressed-errors`; this aligns the third.
+* Bump `nrepl` 1.6.0 → 1.7.0.
 
 ## 3.12.0 (2026-05-10)
 

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :url "https://github.com/clojure-emacs/refactor-nrepl"
   :license {:name "Eclipse Public License"
             :url "https://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[nrepl "1.6.0" :exclusions [org.clojure/clojure]]
+  :dependencies [[nrepl "1.7.0" :exclusions [org.clojure/clojure]]
                  [org.clojure/tools.deps "0.23.1512" :exclusions [org.clojure/clojure
                                                                   org.clojure/core.async
                                                                   org.codehaus.plexus/plexus-utils]]


### PR DESCRIPTION
Single-dep bump, minor release of nrepl. No API breaks affecting refactor-nrepl. First of the per-dep PRs now that the test flake from #430 is fixed.