### PR TITLE
CI: capture test output as artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,13 @@ jobs:
           steps:
             - run:
                 name: Running tests with inlined deps
-                command: make test
+                command: |
+                  mkdir -p target
+                  make test 2>&1 | tee target/test-output.log
+                  exit ${PIPESTATUS[0]}
+            - store_artifacts:
+                path: target/test-output.log
+                when: always
   exercise_code_jarring:
     description: |
       Exercise jarring against given version of JDK and Clojure


### PR DESCRIPTION
Currently CircleCI's job-log view is truncated, so when a flaky test errors we only see the printed exception traces from `maybe-log-exception` (which are *caught* — red herrings) and never the actual `ERROR in (test-name)` line that produced the `1 errors` count.

Tee the test output to `target/test-output.log` and `store_artifacts` it. Uses `PIPESTATUS` so a tee'd failure still fails the step, and `when: always` so the artifact uploads even on failure. Next time the suggest-libspecs flake fires, we can download the log and grep for the real failing test.