### PR TITLE
Bump error_prone_annotations to 2.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Bump `eastwood` 1.4.0 → 1.4.3 (lint dependency).
 * Bump `piggieback` 0.6.0 → 0.6.1 (test dependency).
 * Bump `orchard` 0.39.0 → 0.41.0.
+* Bump `error_prone_annotations` 2.20.0 → 2.49.0 (pedantic dependency).
 
 ## 3.12.0 (2026-05-10)
 

--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,7 @@
                                        [org.clojure/clojure "1.12.0"]
                                        ;; For satisfying `:pedantic?`:
                                        [com.google.code.findbugs/jsr305 "3.0.2"]
-                                       [com.google.errorprone/error_prone_annotations "2.20.0"]]}
+                                       [com.google.errorprone/error_prone_annotations "2.49.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :1.11 {:dependencies [[org.clojure/clojure "1.11.1"]]}
              :1.12 {:dependencies [[org.clojure/clojure "1.12.0"]]}


### PR DESCRIPTION
Pedantic-only dep bump (it's not directly used — only added to satisfy `:pedantic? :abort`).