### PR TITLE
Bump Clojure 1.12.0 to 1.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Bump `piggieback` 0.6.0 → 0.6.1 (test dependency).
 * Bump `orchard` 0.39.0 → 0.41.0.
 * Bump `error_prone_annotations` 2.20.0 → 2.49.0 (pedantic dependency).
+* Bump `clojure` (in matrix's `:1.12` cell) 1.12.0 → 1.12.4.
 
 ## 3.12.0 (2026-05-10)
 

--- a/project.clj
+++ b/project.clj
@@ -36,13 +36,13 @@
   :filespecs [{:type :bytes :path "refactor-nrepl/refactor-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
   :profiles {;; Clojure versions matrix
              :provided {:dependencies [[cider/cider-nrepl "0.55.7"]
-                                       [org.clojure/clojure "1.12.0"]
+                                       [org.clojure/clojure "1.12.4"]
                                        ;; For satisfying `:pedantic?`:
                                        [com.google.code.findbugs/jsr305 "3.0.2"]
                                        [com.google.errorprone/error_prone_annotations "2.49.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :1.11 {:dependencies [[org.clojure/clojure "1.11.1"]]}
-             :1.12 {:dependencies [[org.clojure/clojure "1.12.0"]]}
+             :1.12 {:dependencies [[org.clojure/clojure "1.12.4"]]}
 
              :dev {}
              :test {:dependencies [[cider/piggieback "0.6.1"]


### PR DESCRIPTION
Picks up the latest patch release for the 1.12 matrix cell (and the `:provided` profile).