### PR TITLE
Bump actions/checkout to v6

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create GitHub Release with Auto-Generated Notes
         uses: ncipollo/release-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Bump `error_prone_annotations` 2.20.0 → 2.49.0 (pedantic dependency).
 * Bump `clojure` (in matrix's `:1.12` cell) 1.12.0 → 1.12.4.
 * Bump `leiningen-core` 2.11.2 → 2.12.0 (test dependency).
+* Bump `actions/checkout` v4 → v6 in the GitHub Release workflow.
 
 ## 3.12.0 (2026-05-10)
 


### PR DESCRIPTION
Latest major version. Only used in the GitHub Release workflow (the one that builds release notes on tag push).