### PR TITLE
Bump cider-nrepl to 0.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Bump `error_prone_annotations` 2.20.0 → 2.49.0 (pedantic dependency).
 * Bump `clojure` (in matrix's `:1.12` cell) 1.12.0 → 1.12.4.
 * Bump `leiningen-core` 2.11.2 → 2.12.0 (test dependency).
+* Bump `cider-nrepl` (provided/test dependency) 0.55.7 → 0.59.0. The piggieback wiring previously delegated to `cider.nrepl.middleware.util.cljs/requires-piggieback`, which became a deprecated no-op in 0.59; that wiring is now inlined inside `refactor-nrepl.middleware`.
 * Bump `actions/checkout` v4 → v6 in the GitHub Release workflow.
 
 ## 3.12.0 (2026-05-10)

--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,7 @@
                :unresolved-tree false}
   :filespecs [{:type :bytes :path "refactor-nrepl/refactor-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
   :profiles {;; Clojure versions matrix
-             :provided {:dependencies [[cider/cider-nrepl "0.55.7"]
+             :provided {:dependencies [[cider/cider-nrepl "0.59.0"]
                                        [org.clojure/clojure "1.12.4"]
                                        ;; For satisfying `:pedantic?`:
                                        [com.google.code.findbugs/jsr305 "3.0.2"]

--- a/src/refactor_nrepl/middleware.clj
+++ b/src/refactor_nrepl/middleware.clj
@@ -1,12 +1,24 @@
 (ns refactor-nrepl.middleware
   (:require
-   [cider.nrepl.middleware.util.cljs :as cljs]
    [clojure.stacktrace :refer [print-cause-trace]]
    [clojure.walk :as walk]
    [refactor-nrepl.config :as config]
    [refactor-nrepl.core :as core]
    [refactor-nrepl.ns.libspec-allowlist :as libspec-allowlist]
    [refactor-nrepl.stubs-for-interface :refer [stubs-for-interface]]))
+
+(defn- maybe-require-piggieback
+  "If piggieback is on the classpath, return `descriptor` with piggieback's
+  `wrap-cljs-repl` middleware var added to its `:requires` set; otherwise
+  return `descriptor` unchanged.
+
+  Inlined here instead of calling `cider.nrepl.middleware.util.cljs/requires-piggieback`,
+  which became a deprecated no-op in cider-nrepl 0.59."
+  [descriptor]
+  (if-let [pb (try (requiring-resolve 'cider.piggieback/wrap-cljs-repl)
+                   (catch Exception _ nil))]
+    (update descriptor :requires (fnil conj #{}) pb)
+    descriptor))
 
 ;; Compatibility with the legacy tools.nrepl.
 ;; It is not recommended to use the legacy tools.nrepl,
@@ -219,7 +231,7 @@
 
 (set-descriptor!
  #'wrap-refactor
- (cljs/requires-piggieback
+ (maybe-require-piggieback
   {:handles (into {}
                   (map (fn [op] [op (describe-op op)]))
                   (keys @refactor-nrepl-ops))}))


### PR DESCRIPTION
cider-nrepl 0.59 deprecated `cider.nrepl.middleware.util.cljs/requires-piggieback` to a no-op. Inlining the same logic locally so the descriptor still gets piggieback's `wrap-cljs-repl` in its `:requires` set.