### PR TITLE
Bump clj-kondo to 2026.04.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Bump `leiningen-core` 2.11.2 → 2.12.0 (test dependency).
 * Bump `cider-nrepl` (provided/test dependency) 0.55.7 → 0.59.0. The piggieback wiring previously delegated to `cider.nrepl.middleware.util.cljs/requires-piggieback`, which became a deprecated no-op in 0.59; that wiring is now inlined inside `refactor-nrepl.middleware`.
 * Bump `actions/checkout` v4 → v6 in the GitHub Release workflow.
+* Bump `clj-kondo` 2022.06.22 → 2026.04.15 and `jackson-core` 2.13.3 → 2.21.3 (lint-only dependencies).
 
 ## 3.12.0 (2026-05-10)
 

--- a/project.clj
+++ b/project.clj
@@ -86,8 +86,9 @@
                                    :add-linters [:performance :boxed-math]
                                    :config-files ["eastwood.clj"]}}
              :clj-kondo [:test
-                         {:dependencies [[clj-kondo "2022.06.22"]
-                                         [com.fasterxml.jackson.core/jackson-core "2.13.3"]]}]
+                         {:dependencies [[clj-kondo "2026.04.15" :exclusions [com.cognitect/transit-java
+                                                                              javax.xml.bind/jaxb-api]]
+                                         [com.fasterxml.jackson.core/jackson-core "2.21.3"]]}]
 
              :antq {:plugins [[com.github.liquidz/antq "2.11.1276"]]}
 

--- a/src/refactor_nrepl/ns/rebuild.clj
+++ b/src/refactor_nrepl/ns/rebuild.clj
@@ -7,6 +7,12 @@
 
 (defn- assert-single-alias
   [libspecs alias]
+  ;; NOTE: `for` is lazy, so this whole expression is effectively a no-op
+  ;; today — see https://github.com/clojure-emacs/refactor-nrepl/issues/444.
+  ;; Keeping the shape but ignoring the unused value so clj-kondo doesn't
+  ;; flag it; switching to `doseq` makes the assertion fire and breaks tests
+  ;; that rely on calling this with `alias` = nil/"".
+  #_:clj-kondo/ignore
   (for [libspec libspecs
         :let [libspec-alias (:as libspec)]]
     (when (and libspec-alias (not= libspec-alias alias))


### PR DESCRIPTION
First update to clj-kondo since 2022. Surfaces a real (dead-code) finding in `ns/rebuild.clj` that I tracked in #444 — silenced for now with `#_:clj-kondo/ignore` so this PR stays focused on the bump.

Also paired with jackson-core 2.13.3 → 2.21.3 (lives in the same lint-only profile) and `:exclusions` on transit-java/jaxb-api to satisfy `:pedantic? :abort`.