### PR TITLE
Bump Clojure 1.12.4 to 1.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Bump `cider-nrepl` (provided/test dependency) 0.55.7 → 0.59.0. The piggieback wiring previously delegated to `cider.nrepl.middleware.util.cljs/requires-piggieback`, which became a deprecated no-op in 0.59; that wiring is now inlined inside `refactor-nrepl.middleware`.
 * Bump `actions/checkout` v4 → v6 in the GitHub Release workflow.
 * Bump `clj-kondo` 2022.06.22 → 2026.04.15 and `jackson-core` 2.13.3 → 2.21.3 (lint-only dependencies).
+* Bump `clojure` (in matrix's `:1.12` cell) 1.12.4 → 1.12.5.
 
 ## 3.12.0 (2026-05-10)
 

--- a/project.clj
+++ b/project.clj
@@ -36,13 +36,13 @@
   :filespecs [{:type :bytes :path "refactor-nrepl/refactor-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
   :profiles {;; Clojure versions matrix
              :provided {:dependencies [[cider/cider-nrepl "0.59.0"]
-                                       [org.clojure/clojure "1.12.4"]
+                                       [org.clojure/clojure "1.12.5"]
                                        ;; For satisfying `:pedantic?`:
                                        [com.google.code.findbugs/jsr305 "3.0.2"]
                                        [com.google.errorprone/error_prone_annotations "2.49.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :1.11 {:dependencies [[org.clojure/clojure "1.11.1"]]}
-             :1.12 {:dependencies [[org.clojure/clojure "1.12.4"]]}
+             :1.12 {:dependencies [[org.clojure/clojure "1.12.5"]]}
 
              :dev {}
              :test {:dependencies [[cider/piggieback "0.6.1"]


### PR DESCRIPTION
Latest patch release for the 1.12 matrix cell.