### PR TITLE
Bump core.async to 1.9.865

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Bump `actions/checkout` v4 → v6 in the GitHub Release workflow.
 * Bump `clj-kondo` 2022.06.22 → 2026.04.15 and `jackson-core` 2.13.3 → 2.21.3 (lint-only dependencies).
 * Bump `clojure` (in matrix's `:1.12` cell) 1.12.4 → 1.12.5.
+* Bump `core.async` 1.6.673 → 1.9.865 (test dependency).
 
 ## 3.12.0 (2026-05-10)
 

--- a/project.clj
+++ b/project.clj
@@ -47,7 +47,7 @@
              :dev {}
              :test {:dependencies [[cider/piggieback "0.6.1"]
                                    [org.clojure/clojurescript "1.11.60"]
-                                   [org.clojure/core.async "1.6.673" :exclusions [org.clojure/clojure org.clojure/tools.reader]]
+                                   [org.clojure/core.async "1.9.865" :exclusions [org.clojure/clojure org.clojure/tools.reader]]
                                    [commons-io/commons-io "2.22.0"]
                                    [leiningen-core "2.12.0"
                                     :exclusions [org.clojure/clojure


### PR DESCRIPTION
Test dependency. Verified locally on Clojure 1.10 (the riskiest matrix cell) — 161 tests, 0 failures. core.async 1.9 only uses `requiring-resolve` from Clojure 1.10+, no 1.11-only features.